### PR TITLE
fix(tabs): repair bottom tab bar rendering after OKLCH refactor

### DIFF
--- a/packages/modules/tabs/src/lib/components/tabs-radix.scss
+++ b/packages/modules/tabs/src/lib/components/tabs-radix.scss
@@ -62,10 +62,10 @@
         .trigger-non-active {
           background-color: var(--color-button-blue);
           &:before {
-            @include left-curve('%23288eb9');
+            @include left-curve('%2316b3eb');
           }
           &:after {
-            @include left-curve('%23288eb9');
+            @include left-curve('%2316b3eb');
           }
         }
       }
@@ -74,10 +74,10 @@
         background: var(--color-bg-app);
         &:before {
           left: -33px;
-          @include left-curve('%23141432');
+          @include left-curve('%23050517');
         }
         &:after {
-          @include left-curve('%23141432');
+          @include left-curve('%23050517');
         }
       }
 
@@ -85,10 +85,10 @@
         background: var(--primary-500);
         &:before {
           left: -33px;
-          @include left-curve('%23a35bbb');
+          @include left-curve('%237d40c8');
         }
         &:after {
-          @include left-curve('%23a35bbb');
+          @include left-curve('%237d40c8');
         }
       }
 

--- a/packages/modules/tabs/src/lib/components/tabs-radix.scss
+++ b/packages/modules/tabs/src/lib/components/tabs-radix.scss
@@ -47,6 +47,7 @@
       font-size: var(--font-size-sm);
       cursor: pointer;
       height: 100%;
+      padding: 0;
       display: flex;
       justify-content: center;
       align-items: center;


### PR DESCRIPTION
## Summary

The bottom tab bar regressed after the OKLCH color refactor (`aeeaeba`). This PR restores its original clean rendering with two small, targeted fixes in `packages/modules/tabs/src/lib/components/tabs-radix.scss` (SCSS only, no logic changes).

## 1. Curve colors desynced from the tab body

Each tab's rounded left/right "wings" are inline SVGs (the `left-curve()` mixin) with **hardcoded hex colors** that must match the tab body's `background`. The OKLCH refactor repointed the body background tokens but left the curve hexes frozen at the old palette, so every tab's shoulders rendered a different color than its body (visible mismatched blobs, most obvious on the purple leaf tab and the dark active tab).

Updated the three curve hexes to match their tab-body variables:

| element | body background | old hex → new hex |
|---|---|---|
| `.trigger-active`   | `--color-bg-app` (`--surface-900`) | `#141432` → `#050517` |
| `.trigger-terminal` | `--primary-500`                    | `#a35bbb` → `#7d40c8` |
| hover               | `--color-button-blue` (`--cyan-300`) | `#288eb9` → `#16b3eb` |

## 2. 1px band of bar color above/below each tab

`Tabs.Trigger` renders a `<button>`, which UA styles give `box-sizing: border-box` **plus** a default `~1px` vertical padding. With `.TabsTrigger { height: 100% }`, that padding ate ~1px off the top and bottom of the colored inner `.trigger-*`, so the tab rendered ~28px tall inside the 30px bar and was vertically centered — exposing a 1px strip of `--surface-700` (bar color) above and below every tab.

Fix: `padding: 0` on `.TabsTrigger` so the colored tab fills the full bar height with no seam.

## Testing

Verified in an isolated reproduction using the exact tab DOM, the compiled SCSS, and the real design-token values (the full app requires the Docker/DNS/gateway stack). Pixel-tracing a high-DPI render confirmed the colored tab now spans the full bar height (no `--surface-700` band) and the curve wings match their tab bodies. CI on this PR is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)