### PR TITLE
fix(networking): correct org vhost regex + make Docker-host IP overridable

### DIFF
--- a/doc/architecture/GATEWAY_ARCHITECTURE.md
+++ b/doc/architecture/GATEWAY_ARCHITECTURE.md
@@ -787,9 +787,11 @@ Registry of permission definitions registered by modules (no persistence).
 - `GET /permissions` (TJwtUser) - List all permissions
 - `GET /permissions/projects/{id}` (TJwtUser) - Get project user permissions
 - `PATCH /permissions/projects/{id}/users/{id}` (TJwtUser) - Update user permissions
-- `GET /oauth/authorize` (TJwtUser) - OAuth authorization for container apps
-- `POST /oauth/token` - OAuth token exchange
-- `POST /oauth/authenticate` (OAuth Bearer token) - Validate OAuth token
+> **Removed:** the gateway no longer hosts OAuth endpoints. OAuth was centralized
+> in Ganymede and per-container access is now enforced by the Auth Guard Proxy.
+> The former `GET /oauth/authorize`, `POST /oauth/token`, and `POST /oauth/authenticate`
+> on the gateway have been deleted (see `AUTH_GUARD_PROXY.md`); the gateway now
+> exposes `POST /containers/:id/verify-access` instead. Do not call gateway `/oauth/*`.
 
 ---
 

--- a/packages/app-ganymede/src/services/nginx-manager.spec.ts
+++ b/packages/app-ganymede/src/services/nginx-manager.spec.ts
@@ -85,6 +85,39 @@ describe('NginxManager - Path Injection Protection', () => {
     });
   });
 
+  describe('createGatewayConfig - server_name regex escaping', () => {
+    const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+    const writtenConfig = async (): Promise<string> => {
+      await nginxManager.createGatewayConfig(validUuid, '172.17.0.1:7100');
+      const calls = (fs.promises.writeFile as jest.Mock).mock.calls;
+      return calls[calls.length - 1][1] as string;
+    };
+
+    it('escapes domain dots with a SINGLE backslash (not double)', async () => {
+      const config = await writtenConfig();
+      // DOMAIN is 'test.local' (set in beforeEach)
+      expect(config).toContain(
+        `server_name ~^(.+\\.)?org-${validUuid}\\.test\\.local$;`
+      );
+      // Regression guard: a doubled escape (`test\\.local`) never matches the
+      // real hostname and routes org-* traffic to the default server.
+      expect(config).not.toContain('test\\\\.local');
+    });
+
+    it('produces a server_name regex that matches org and nested subdomains', async () => {
+      const config = await writtenConfig();
+      const match = config.match(/server_name\s+~\^(.+?)\$;/);
+      expect(match).not.toBeNull();
+      const re = new RegExp('^' + (match as RegExpMatchArray)[1] + '$');
+      expect(re.test(`org-${validUuid}.test.local`)).toBe(true);
+      expect(re.test(`uc-1.org-${validUuid}.test.local`)).toBe(true);
+      expect(re.test(`svc.uc-1.org-${validUuid}.test.local`)).toBe(true);
+      // must NOT match a different org
+      expect(re.test('org-other.test.local')).toBe(false);
+    });
+  });
+
   describe('createGatewayConfig - Path Traversal Attacks', () => {
     it('should reject organization ID with path traversal (..) characters', async () => {
       const maliciousId = '../../../etc/passwd';

--- a/packages/app-ganymede/src/services/nginx-manager.ts
+++ b/packages/app-ganymede/src/services/nginx-manager.ts
@@ -65,8 +65,13 @@ export class NginxManager {
       `Creating config for ${orgDomain} → ${gatewayAddress}`
     );
 
-    // Escape dots in domain for regex
-    const domainEscaped = domain.replace(/\./g, '\\\\.');
+    // Escape dots in domain for the regex server_name.
+    // The result is embedded into a template that already treats `\.` as a
+    // literal-dot matcher, so we must produce a SINGLE backslash here. Using
+    // '\\\\.' (two backslashes) yields `domain\\.local`, which in PCRE means
+    // "backslash + any char" and never matches the real hostname — silently
+    // routing every org-*/uc-* request to the default (frontend) server.
+    const domainEscaped = domain.replace(/\./g, '\\.');
 
     // Create nginx config (Stage 1: SSL termination, route to gateway)
     // Use regex server_name to match nested subdomains:

--- a/packages/modules/user-containers/src/lib/runner.ts
+++ b/packages/modules/user-containers/src/lib/runner.ts
@@ -64,7 +64,10 @@ export abstract class ContainerRunner {
     // to the Docker bridge gateway IP which routes to the host/dev container
     let addHostFlags = '';
     if (process.env.GATEWAY_DEV === '1') {
-      const hostIp = '172.17.0.1';
+      // Docker-host address. Defaults to the Linux docker0 bridge gateway
+      // (172.17.0.1). On Docker Desktop (macOS/Windows) that IP does not reach
+      // the host, so allow overriding via DOCKER_HOST_IP=host.docker.internal.
+      const hostIp = process.env.DOCKER_HOST_IP || '172.17.0.1';
       addHostFlags = `--add-host=${config.gateway_fqdn}:${hostIp} --add-host=${config.ganymede_fqdn}:${hostIp} `;
     }
 

--- a/scripts/local-dev/create-env.sh
+++ b/scripts/local-dev/create-env.sh
@@ -261,8 +261,11 @@ SESSION_COOKIE_KEY=$(openssl rand -hex 32)
 # installations and won't change unless you manually reconfigure Docker's bridge network.
 #
 # Verified by: docker network inspect bridge | jq '.[0].IPAM.Config[0].Gateway'
-OTLP_ENDPOINT_HTTP=http://172.17.0.1:4318
-OTLP_ENDPOINT_GRPC=http://172.17.0.1:4317
+#
+# 172.17.0.1 is the Linux docker0 bridge gateway. On Docker Desktop (macOS/Windows)
+# it does NOT reach the host — override with DOCKER_HOST_IP=host.docker.internal.
+OTLP_ENDPOINT_HTTP=http://${DOCKER_HOST_IP:-172.17.0.1}:4318
+OTLP_ENDPOINT_GRPC=http://${DOCKER_HOST_IP:-172.17.0.1}:4317
 # Service name for this environment (used in traces/logs)
 OTEL_SERVICE_NAME=ganymede-${ENV_NAME}
 # Deployment environment (used for filtering in Grafana)

--- a/scripts/local-dev/gateway-pool.sh
+++ b/scripts/local-dev/gateway-pool.sh
@@ -250,9 +250,11 @@ cmd_create() {
         echo -e "${BLUE}  Creating ${gateway_name}...${NC}"
         
         # Register gateway in database
-        # For development, nginx_upstream is always Docker host IP (172.17.0.1) + HTTP port
-        # This is the address that Stage 1 Nginx (in main dev container) uses to reach gateway containers
-        local nginx_upstream="172.17.0.1:${gw_http_port}"
+        # For development, nginx_upstream is the Docker host IP + HTTP port.
+        # This is the address that Stage 1 Nginx (in main dev container) uses to reach gateway containers.
+        # Defaults to the Linux docker0 bridge gateway (172.17.0.1); override with
+        # DOCKER_HOST_IP (e.g. host.docker.internal) on Docker Desktop / macOS.
+        local nginx_upstream="${DOCKER_HOST_IP:-172.17.0.1}:${gw_http_port}"
         
         echo "     Registering in database..."
         echo "     Gateway: ${gateway_name}, HTTP: ${gw_http_port}, VPN: ${gw_vpn_port}"
@@ -305,15 +307,15 @@ cmd_create() {
         container_env[JWT_PUBLIC_KEY]="${JWT_PUBLIC_KEY}"
         
         # OpenTelemetry configuration
-        # Gateway containers need to reach OTLP Collector on the Docker host.
-        # 172.17.0.1 is the Docker bridge gateway IP - it allows containers
-        # to reach services exposed on the host (OTLP ports 4317/4318).
-        # This is necessary because 'localhost' inside a container refers to
-        # the container itself, not the Docker host.
+        # Gateway containers need to reach the OTLP Collector on the Docker host.
+        # Defaults to the Linux docker0 bridge gateway (172.17.0.1); on Docker
+        # Desktop / macOS that IP does not reach the host, so override with
+        # DOCKER_HOST_IP=host.docker.internal.
+        # 'localhost' inside a container refers to the container itself, not the host.
         container_env[OTEL_SERVICE_NAME]="gateway-${gateway_name}"
         container_env[OTEL_DEPLOYMENT_ENVIRONMENT]="${ENV_NAME}"
-        container_env[OTLP_ENDPOINT_HTTP]="http://172.17.0.1:4318"
-        container_env[OTLP_ENDPOINT_GRPC]="http://172.17.0.1:4317"
+        container_env[OTLP_ENDPOINT_HTTP]="http://${DOCKER_HOST_IP:-172.17.0.1}:4318"
+        container_env[OTLP_ENDPOINT_GRPC]="http://${DOCKER_HOST_IP:-172.17.0.1}:4317"
         
         # SSL/TLS Configuration (LOCAL DEVELOPMENT ONLY)
         # Disable certificate verification for self-signed certificates


### PR DESCRIPTION
## Summary

Fixes the local-dev networking breakage where org/gateway/user-container URLs don't route as intended. Three targeted changes plus one verified non-change.

## 1. Org vhost `server_name` regex double-escaped the domain (root cause)

`packages/app-ganymede/src/services/nginx-manager.ts` built the per-org nginx `server_name` with a **doubled** backslash escape:

```js
const domainEscaped = domain.replace(/\./g, '\\\\.');   // wrong
```

The value is interpolated into a template that already treats `\.` as a literal-dot matcher, so it emitted:

```
server_name ~^(.+\.)?org-{uuid}\.domain\\.local$;
```

In PCRE `domain\\.local` means *"domain" + literal backslash + any char + "local"* — it **never matches** `org-{uuid}.domain.local`. `nginx -t` passes (valid regex, wrong semantics), so allocation "succeeds," but on :443 the org vhost matches nothing and every request **falls through to the default server (the frontend SPA)**. Result: gateway API, `/collab/*`, the YJS **WebSocket**, and all user-container URLs return frontend HTML / 404 instead of proxying. Introduced by `4e4649e` ("per-service FQDN routing").

**Fix:** single backslash (`replace(/\./g, '\\.')`), matching the intended form in `AUTH_GUARD_PROXY.md`.

## 2. Docker-host IP is now overridable (macOS / Docker Desktop)

The stack hardcodes `172.17.0.1` (the Linux `docker0` bridge gateway) as "the Docker host" in the nginx upstream, OTLP endpoints, and user-container `--add-host`. On Docker Desktop that IP doesn't reach the host. Made it overridable via **`DOCKER_HOST_IP`** (default unchanged: `172.17.0.1`) in `gateway-pool.sh`, `create-env.sh`, and `runner.ts`. Linux behavior is identical; on macOS set `DOCKER_HOST_IP=host.docker.internal`.

## 3. Docs: removed gateway `/oauth/*` marked as deleted

`GATEWAY_ARCHITECTURE.md` still advertised gateway `/oauth/*` endpoints removed in `4e7a33d` (OAuth centralized in Ganymede + Auth Guard Proxy). Confirmed no `/oauth` routes remain in the gateway; annotated the doc.

## Verified NON-change

`/collab/vpn-config` returning a bare object (not `{ data: ... }`) is **correct** — the consumer `container-functions.sh` parses `jq -r '.certificates'` / `.config` off the bare object. Left as-is.

## Testing

- `nginx-manager.spec.ts`: added 2 regression tests asserting the generated `server_name` uses a single-backslash escape and functionally matches `org-{uuid}.domain`, `uc-1.org-{uuid}.domain`, and nested service subdomains (and rejects other orgs).
- **Ran locally:** `app-ganymede` suite green (111 passed / 1 skipped, 8/8 suites); `nginx-manager.spec.ts` 26/26. Reintroducing the bug makes the 2 new tests fail; the fix makes them pass. `@holistix-forge/app-ganymede:typecheck` passes.
- **Not run:** end-to-end (requires the live dev-container + Docker/CoreDNS/nginx/Postgres/gateway stack). CI is the authoritative check for the shell/env changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)