### PR TITLE
chore(storybook): repair visual regression suite and close 6-month maintenance gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,11 +239,18 @@ jobs:
       - name: Comment on PR with visual regression results
         if: github.event_name == 'pull_request' && steps.visual-tests.outputs.has_failures == 'true'
         uses: actions/github-script@v7
+        # Values are passed through the environment, never interpolated into the
+        # script body: diff filenames are wrapped in backticks, which would close
+        # the template literal below and break the script (or allow injection).
+        env:
+          FAILED_PACKAGES: ${{ steps.visual-tests.outputs.FAILED_PACKAGES }}
+          DIFF_FILES: ${{ steps.visual-tests.outputs.DIFF_FILES }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const failedPackages = `${{ steps.visual-tests.outputs.FAILED_PACKAGES }}`;
-            const diffFiles = `${{ steps.visual-tests.outputs.DIFF_FILES }}`;
-            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const failedPackages = process.env.FAILED_PACKAGES || '';
+            const diffFiles = process.env.DIFF_FILES || '';
+            const runUrl = process.env.RUN_URL;
 
             const body = `## 📸 Visual Regression Detected
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -29,6 +29,7 @@ Welcome to the Holistix Forge documentation! This hub will guide you to the righ
 - 🧪 **[Test Modules](guides/MODULES_TESTING.md)** - Module stories and fake collab
 - 📦 **[Use Nx Workspace](guides/NX_WORKSPACE.md)** - Monorepo commands and workflows
 - 🎨 **[Build UI Components](guides/MODULES_TESTING.md)** - Module development with Storybook
+- 📸 **[Storybook & Visual Regression](guides/STORYBOOK.md)** - Story conventions, screenshot baselines, CI
 - 🔧 **[Package Architecture](guides/PACKAGE_ARCHITECTURE.md)** - React dependency management and package patterns
 - 🚀 **[Gateway Build Distribution](guides/GATEWAY_BUILD_DISTRIBUTION.md)** - HTTP build distribution system
 - 🔌 **[Module Reference](../packages/modules/README.md)** - Individual module documentation
@@ -94,8 +95,9 @@ doc/
 1. [Local Development Setup](guides/LOCAL_DEVELOPMENT.md)
 2. [Testing Guide](guides/TESTING_GUIDE.md) (React components, LocalStorage)
 3. [Module Testing with Storybook](guides/MODULES_TESTING.md)
-4. [Nx Workspace Guide](guides/NX_WORKSPACE.md)
-5. [API Reference](reference/API.md) (for backend integration)
+4. [Storybook & Visual Regression](guides/STORYBOOK.md)
+5. [Nx Workspace Guide](guides/NX_WORKSPACE.md)
+6. [API Reference](reference/API.md) (for backend integration)
 
 ### Backend Developer
 

--- a/doc/guides/STORYBOOK.md
+++ b/doc/guides/STORYBOOK.md
@@ -1,0 +1,200 @@
+# Storybook & Visual Regression
+
+How the Storybook setup works in this monorepo, and how to keep it healthy.
+
+## Table of Contents
+
+1. [Layout](#layout)
+2. [Running a Storybook](#running-a-storybook)
+3. [Writing a Story](#writing-a-story)
+4. [Visual Regression Suite](#visual-regression-suite)
+5. [Screenshot Baselines](#screenshot-baselines)
+6. [Excluding a Story from the Screenshot Suite](#excluding-a-story-from-the-screenshot-suite)
+7. [Troubleshooting](#troubleshooting)
+
+---
+
+## Layout
+
+Eleven packages ship their own Storybook. Each one has a `.storybook/` directory
+and a `tsconfig.storybook.json`:
+
+| Package                            | Scope                    |
+| ---------------------------------- | ------------------------ |
+| `packages/ui-base`                 | Design system primitives |
+| `packages/ui-views`                | Composed views and forms |
+| `packages/modules/airtable`        | Module                   |
+| `packages/modules/chats`           | Module                   |
+| `packages/modules/excalidraw`      | Module                   |
+| `packages/modules/jupyter`         | Module                   |
+| `packages/modules/notion`          | Module                   |
+| `packages/modules/socials`         | Module                   |
+| `packages/modules/tabs`            | Module                   |
+| `packages/modules/user-containers` | Module                   |
+| `packages/modules/whiteboard`      | Module                   |
+
+Targets are inferred by the `@nx/storybook` plugin (see `nx.json`), so there is
+no per-package target to declare:
+
+| Target            | What it does                           |
+| ----------------- | -------------------------------------- |
+| `storybook`       | Serves the Storybook in dev mode       |
+| `build-storybook` | Builds a static Storybook              |
+| `test-storybook`  | Runs the screenshot / smoke test suite |
+
+The `.storybook/` contents are intentionally uniform across packages:
+
+- `main.ts` — stories glob + `addon-essentials` and `addon-interactions`
+- `preview.ts` — dark background, global decorator, design-system stylesheet
+- `global-wrapper.tsx` — the decorator itself
+- `test-runner.js` — screenshot capture and comparison
+
+Keep them aligned. Divergence between packages is how this setup rots.
+
+---
+
+## Running a Storybook
+
+```bash
+npx nx run @holistix-forge/ui-base:storybook          # dev server
+npx nx run @holistix-forge/ui-base:build-storybook    # static build
+```
+
+---
+
+## Writing a Story
+
+Stories live next to the component: `my-component.tsx` →
+`my-component.stories.tsx`. Every exported component in a package's public API
+should have one.
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { MyComponent } from './my-component';
+
+const meta = {
+  title: 'Basics/MyComponent',
+  component: MyComponent,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof MyComponent>;
+
+export const Normal: Story = { args: { label: 'Hello' } };
+```
+
+**Every story is screenshotted.** That has two consequences:
+
+- **Fixtures must be deterministic.** No `Math.random()`, no `Date.now()`, no
+  generated ids or colors, no remote avatars. Put shared fixtures in a
+  `*-mocks.ts` next to the stories (see
+  `packages/ui-base/src/lib/credentials/credentials-mocks.ts`).
+- **`satisfies Meta<typeof X>` requires the props type to be exported** from the
+  component module, otherwise `tsc` raises `TS4023`.
+
+---
+
+## Visual Regression Suite
+
+`.storybook/test-runner.js` visits every story, waits for fonts and layout to
+settle, disables CSS animations, then screenshots `#storybook-root` and compares
+it against a committed baseline (`jest-image-snapshot`, 0.2% pixel tolerance).
+
+Run it for one package:
+
+```bash
+npx nx run @holistix-forge/ui-base:build-storybook
+npx http-server packages/ui-base/storybook-static -p 6006 --silent &
+npx test-storybook --url http://127.0.0.1:6006 --config-dir packages/ui-base/.storybook
+```
+
+Or across the workspace:
+
+```bash
+npm run test:visual          # compare
+npm run test:visual:update   # regenerate baselines
+```
+
+In CI the `visual-regression` job (`.github/workflows/ci.yml`) runs the same
+thing on `ubuntu-24.04`. It is **non-blocking**: on a difference it uploads the
+diff images as an artifact and posts a PR comment, it does not fail the build.
+
+---
+
+## Screenshot Baselines
+
+Baselines live in `packages/**/__screenshots__/` and **are committed**. Diff
+output lands in `__diff_output__/`, which is gitignored.
+
+> **Baselines are platform-specific.** They are generated on Linux, matching the
+> `ubuntu-24.04` CI runner. Regenerating them on a macOS host produces images
+> that differ on font rasterization alone — same layout, same colors, different
+> antialiasing — and every story then reports a 3-6% diff in CI.
+>
+> Regenerate baselines **inside the Linux dev container or from CI**, never from
+> a macOS host.
+
+When you add stories from a macOS host, leave the baselines out of the commit.
+CI will report the missing snapshots in its PR comment, and the baselines can be
+generated in one pass on Linux:
+
+```bash
+npx nx run <package>:test-storybook -- -u
+```
+
+---
+
+## Excluding a Story from the Screenshot Suite
+
+Some stories cannot be captured deterministically — a live countdown, a
+progress animation, anything driven by the wall clock. Tag them:
+
+```tsx
+export const Running: Story = {
+  tags: ['no-visual-test'],
+  render: () => <Countdown targetDate={new Date(Date.now() + 60_000)} />,
+};
+```
+
+`.storybook/test-runner.js` declares `tags: { skip: ['no-visual-test'] }`, so
+those stories still show up in Storybook but are skipped by the screenshot
+comparison. Use it sparingly — prefer making the fixture deterministic.
+
+---
+
+## Troubleshooting
+
+**`unknown variant 'es2023', expected one of ... es2022`**
+
+`@swc/jest` targets `es2023` on Node ≥ 18; `@swc/core` must be recent enough to
+understand it. The whole suite fails to start ("Test suite failed to run") when
+they drift apart. Keep `@swc/core` current in the root `package.json`.
+
+**`Executable doesn't exist at .../headless_shell`**
+
+```bash
+npx playwright install chromium
+npx playwright install-deps chromium   # Linux only
+```
+
+**`build-storybook` hangs with `--parallel=3`**
+
+Each Storybook build is memory-hungry. Lower the parallelism, or raise the heap:
+
+```bash
+NODE_OPTIONS=--max_old_space_size=4096 npx nx run-many -t build-storybook --parallel=2
+```
+
+**`npm run lint` reports thousands of errors after building Storybook**
+
+`storybook-static/` is an ESLint-ignored build artefact (`eslint.config.cjs`).
+If you see this, the ignore entry is missing — do not lint generated bundles.
+
+---
+
+## Related
+
+- [Testing Guide](TESTING_GUIDE.md)
+- [Module Testing with Storybook](MODULES_TESTING.md)
+- [Style System](STYLE_SYSTEM.md)

--- a/doc/guides/TESTING_GUIDE.md
+++ b/doc/guides/TESTING_GUIDE.md
@@ -332,6 +332,8 @@ npx nx test app-ganymede --coverage
 
 ## 📖 Storybook Stories
 
+> Full setup, screenshot baselines and CI behaviour: **[Storybook & Visual Regression](STORYBOOK.md)**.
+
 ### **Storybook Test Runner**
 
 For testing stories directly:
@@ -343,6 +345,11 @@ npx nx run ui-base:storybook
 # In another terminal, run tests
 npx nx run ui-base:test-storybook
 ```
+
+Every story is also screenshotted and compared against a committed baseline.
+Keep story fixtures deterministic (no `Math.random()`, no `Date.now()`, no
+remote images), and regenerate baselines on Linux only — see
+[STORYBOOK.md](STORYBOOK.md#screenshot-baselines).
 
 ### **Using Story Args in Tests**
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -10,6 +10,10 @@ module.exports = [
       '**/out-tsc',
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
+      // Storybook build artefacts: generated bundles, not sources.
+      '**/storybook-static',
+      '**/__screenshots__',
+      '**/__diff_output__',
     ],
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "@storybook/testing-library": "^0.2.2",
         "@swc-node/register": "~1.9.1",
         "@swc/cli": "~0.3.12",
-        "@swc/core": "~1.5.7",
+        "@swc/core": "~1.15.47",
         "@swc/helpers": "~0.5.11",
         "@swc/jest": "~0.2.36",
         "@testing-library/dom": "^10.4.1",
@@ -17511,15 +17511,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.29.tgz",
-      "integrity": "sha512-nvTtHJI43DUSOAf3h9XsqYg8YXKc0/N4il9y4j0xAkO0ekgDNo+3+jbw6MInawjKJF9uulyr+f5bAutTsOKVlw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
+      "integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.8"
+        "@swc/types": "^0.1.27"
       },
       "engines": {
         "node": ">=10"
@@ -17529,19 +17529,21 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.5.29",
-        "@swc/core-darwin-x64": "1.5.29",
-        "@swc/core-linux-arm-gnueabihf": "1.5.29",
-        "@swc/core-linux-arm64-gnu": "1.5.29",
-        "@swc/core-linux-arm64-musl": "1.5.29",
-        "@swc/core-linux-x64-gnu": "1.5.29",
-        "@swc/core-linux-x64-musl": "1.5.29",
-        "@swc/core-win32-arm64-msvc": "1.5.29",
-        "@swc/core-win32-ia32-msvc": "1.5.29",
-        "@swc/core-win32-x64-msvc": "1.5.29"
+        "@swc/core-darwin-arm64": "1.15.47",
+        "@swc/core-darwin-x64": "1.15.47",
+        "@swc/core-linux-arm-gnueabihf": "1.15.47",
+        "@swc/core-linux-arm64-gnu": "1.15.47",
+        "@swc/core-linux-arm64-musl": "1.15.47",
+        "@swc/core-linux-ppc64-gnu": "1.15.47",
+        "@swc/core-linux-s390x-gnu": "1.15.47",
+        "@swc/core-linux-x64-gnu": "1.15.47",
+        "@swc/core-linux-x64-musl": "1.15.47",
+        "@swc/core-win32-arm64-msvc": "1.15.47",
+        "@swc/core-win32-ia32-msvc": "1.15.47",
+        "@swc/core-win32-x64-msvc": "1.15.47"
       },
       "peerDependencies": {
-        "@swc/helpers": "*"
+        "@swc/helpers": ">=0.5.17"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -17550,9 +17552,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.29.tgz",
-      "integrity": "sha512-6F/sSxpHaq3nzg2ADv9FHLi4Fu2A8w8vP8Ich8gIl16D2htStlwnaPmCLjRswO+cFkzgVqy/l01gzNGWd4DFqA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
+      "integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
       "cpu": [
         "arm64"
       ],
@@ -17567,9 +17569,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.29.tgz",
-      "integrity": "sha512-rF/rXkvUOTdTIfoYbmszbSUGsCyvqACqy1VeP3nXONS+LxFl4bRmRcUTRrblL7IE5RTMCKUuPbqbQSE2hK7bqg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
+      "integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
       "cpu": [
         "x64"
       ],
@@ -17584,9 +17586,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.29.tgz",
-      "integrity": "sha512-2OAPL8iWBsmmwkjGXqvuUhbmmoLxS1xNXiMq87EsnCNMAKohGc7wJkdAOUL6J/YFpean/vwMWg64rJD4pycBeg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
+      "integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
       "cpu": [
         "arm"
       ],
@@ -17601,9 +17603,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.29.tgz",
-      "integrity": "sha512-eH/Q9+8O5qhSxMestZnhuS1xqQMr6M7SolZYxiXJqxArXYILLCF+nq2R9SxuMl0CfjHSpb6+hHPk/HXy54eIRA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
       "cpu": [
         "arm64"
       ],
@@ -17618,9 +17620,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.29.tgz",
-      "integrity": "sha512-TERh2OICAJz+SdDIK9+0GyTUwF6r4xDlFmpoiHKHrrD/Hh3u+6Zue0d7jQ/he/i80GDn4tJQkHlZys+RZL5UZg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
+      "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
       "cpu": [
         "arm64"
       ],
@@ -17634,10 +17636,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
+      "integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
+      "integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.29.tgz",
-      "integrity": "sha512-WMDPqU7Ji9dJpA+Llek2p9t7pcy7Bob8ggPUvgsIlv3R/eesF9DIzSbrgl6j3EAEPB9LFdSafsgf6kT/qnvqFg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
       "cpu": [
         "x64"
       ],
@@ -17652,9 +17688,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.29.tgz",
-      "integrity": "sha512-DO14glwpdKY4POSN0201OnGg1+ziaSVr6/RFzuSLggshwXeeyVORiHv3baj7NENhJhWhUy3NZlDsXLnRFkmhHQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
+      "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
       "cpu": [
         "x64"
       ],
@@ -17669,9 +17705,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.29.tgz",
-      "integrity": "sha512-V3Y1+a1zG1zpYXUMqPIHEMEOd+rHoVnIpO/KTyFwAmKVu8v+/xPEVx/AGoYE67x4vDAAvPQrKI3Aokilqa5yVg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
+      "integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
       "cpu": [
         "arm64"
       ],
@@ -17686,9 +17722,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.29.tgz",
-      "integrity": "sha512-OrM6yfXw4wXhnVFosOJzarw0Fdz5Y0okgHfn9oFbTPJhoqxV5Rdmd6kXxWu2RiVKs6kGSJFZXHDeUq2w5rTIMg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
+      "integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
       "cpu": [
         "ia32"
       ],
@@ -17703,9 +17739,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.29.tgz",
-      "integrity": "sha512-eD/gnxqKyZQQR0hR7TMkIlJ+nCF9dzYmVVNbYZWuA1Xy94aBPUsEk3Uw3oG7q6R3ErrEUPP0FNf2ztEnv+I+dw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
+      "integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
       "cpu": [
         "x64"
       ],
@@ -17755,9 +17791,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
-      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@storybook/testing-library": "^0.2.2",
     "@swc-node/register": "~1.9.1",
     "@swc/cli": "~0.3.12",
-    "@swc/core": "~1.5.7",
+    "@swc/core": "~1.15.47",
     "@swc/helpers": "~0.5.11",
     "@swc/jest": "~0.2.36",
     "@testing-library/dom": "^10.4.1",

--- a/packages/modules/airtable/.storybook/main.ts
+++ b/packages/modules/airtable/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/airtable/.storybook/test-runner.js
+++ b/packages/modules/airtable/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/chats/.storybook/main.ts
+++ b/packages/modules/chats/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/chats/.storybook/test-runner.js
+++ b/packages/modules/chats/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/excalidraw/.storybook/main.ts
+++ b/packages/modules/excalidraw/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/excalidraw/.storybook/test-runner.js
+++ b/packages/modules/excalidraw/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/jupyter/.storybook/main.ts
+++ b/packages/modules/jupyter/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/jupyter/.storybook/test-runner.js
+++ b/packages/modules/jupyter/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/notion/.storybook/main.ts
+++ b/packages/modules/notion/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/notion/.storybook/test-runner.js
+++ b/packages/modules/notion/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/socials/.storybook/main.ts
+++ b/packages/modules/socials/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/socials/.storybook/test-runner.js
+++ b/packages/modules/socials/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/tabs/.storybook/main.ts
+++ b/packages/modules/tabs/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/tabs/.storybook/test-runner.js
+++ b/packages/modules/tabs/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/user-containers/.storybook/main.ts
+++ b/packages/modules/user-containers/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/user-containers/.storybook/test-runner.js
+++ b/packages/modules/user-containers/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/modules/whiteboard/.storybook/main.ts
+++ b/packages/modules/whiteboard/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/packages/modules/whiteboard/.storybook/test-runner.js
+++ b/packages/modules/whiteboard/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/ui-base/.storybook/test-runner.js
+++ b/packages/ui-base/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/ui-base/src/lib/countdown/countdown.stories.tsx
+++ b/packages/ui-base/src/lib/countdown/countdown.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Countdown } from './countdown';
+
+const meta = {
+  title: 'Basics/Countdown',
+  component: Countdown,
+  parameters: { layout: 'centered' },
+  args: {
+    onComplete: () => undefined,
+  },
+} satisfies Meta<typeof Countdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof Countdown>;
+
+/**
+ * Target already in the past: the countdown sits at `00:00` and `onComplete`
+ * has already fired. This is the deterministic story used as the visual
+ * regression baseline.
+ */
+export const Completed: Story = {
+  args: {
+    targetDate: new Date('2020-01-01T00:00:00.000Z'),
+  },
+};
+
+/**
+ * A live countdown. Excluded from the screenshot suite: the rendered digits
+ * change every second.
+ */
+export const Running: Story = {
+  tags: ['no-visual-test'],
+  render: (args) => (
+    <Countdown {...args} targetDate={new Date(Date.now() + 5 * 60 * 1000)} />
+  ),
+  args: {
+    targetDate: new Date('2020-01-01T00:00:00.000Z'),
+  },
+};

--- a/packages/ui-base/src/lib/countdown/countdown.tsx
+++ b/packages/ui-base/src/lib/countdown/countdown.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import './countdown.scss';
-interface CountdownProps {
+export interface CountdownProps {
   targetDate: Date;
   onComplete: () => void;
 }

--- a/packages/ui-base/src/lib/credentials/CredentialCard.stories.tsx
+++ b/packages/ui-base/src/lib/credentials/CredentialCard.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CredentialCard } from './CredentialCard';
+import { mockCredentialTypes, mockCredentials } from './credentials-mocks';
+
+import './credentials.scss';
+
+const noop = () => undefined;
+
+const meta = {
+  title: 'Credentials/CredentialCard',
+  component: CredentialCard,
+  parameters: { layout: 'centered' },
+  args: {
+    onEdit: noop,
+    onDelete: noop,
+    onShare: noop,
+  },
+  decorators: [
+    (Story) => (
+      <div className="credentials-wallet" style={{ width: '560px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CredentialCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof CredentialCard>;
+
+/** Shared credential, already used at least once. */
+export const Shared: Story = {
+  args: {
+    credential: mockCredentials[0],
+    credentialType: mockCredentialTypes[0],
+  },
+};
+
+/** Private credential that has never been used. */
+export const NeverUsed: Story = {
+  args: {
+    credential: mockCredentials[1],
+    credentialType: mockCredentialTypes[1],
+  },
+};
+
+/**
+ * The credential type is unknown to the frontend (module not installed):
+ * the card falls back to the raw type name and the default icon.
+ */
+export const UnknownType: Story = {
+  args: {
+    credential: mockCredentials[2],
+    credentialType: undefined,
+  },
+};
+
+/** No callback provided: the card renders without its action buttons. */
+export const WithoutActions: Story = {
+  args: {
+    credential: mockCredentials[0],
+    credentialType: mockCredentialTypes[0],
+    onEdit: undefined,
+    onDelete: undefined,
+    onShare: undefined,
+  },
+};

--- a/packages/ui-base/src/lib/credentials/CredentialForm.stories.tsx
+++ b/packages/ui-base/src/lib/credentials/CredentialForm.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CredentialForm } from './CredentialForm';
+import { mockCredentialTypes } from './credentials-mocks';
+
+import './credentials.scss';
+
+const noop = () => undefined;
+
+const meta = {
+  title: 'Credentials/CredentialForm',
+  component: CredentialForm,
+  parameters: { layout: 'centered' },
+  args: {
+    types: mockCredentialTypes,
+    onSubmit: noop,
+    onCancel: noop,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '560px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CredentialForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof CredentialForm>;
+
+/** Nothing selected yet: only the type selector is shown. */
+export const Normal: Story = {};
+
+/**
+ * A type is pre-selected, so the name and secret fields are revealed.
+ * Submit stays disabled until both are filled.
+ */
+export const TypePreselected: Story = {
+  args: {
+    initialType: 'openai_api_key',
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    initialType: 'github_token',
+    isSubmitting: true,
+  },
+};

--- a/packages/ui-base/src/lib/credentials/CredentialShareDialog.stories.tsx
+++ b/packages/ui-base/src/lib/credentials/CredentialShareDialog.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CredentialShareDialog } from './CredentialShareDialog';
+import {
+  mockOrganizations,
+  mockProjects,
+  mockShares,
+} from './credentials-mocks';
+
+import './credentials.scss';
+
+const asyncNoop = async () => undefined;
+
+const meta = {
+  title: 'Credentials/CredentialShareDialog',
+  component: CredentialShareDialog,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    credentialId: 'cred-1',
+    credentialName: 'OpenAI — production',
+    organizations: mockOrganizations,
+    projects: mockProjects,
+    shares: [],
+    onShare: asyncNoop,
+    onRevoke: asyncNoop,
+    onClose: () => undefined,
+  },
+} satisfies Meta<typeof CredentialShareDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof CredentialShareDialog>;
+
+/** Credential not shared yet. */
+export const NotShared: Story = {};
+
+/**
+ * Already shared with one organization and one project — those targets are
+ * filtered out of the "add a share" selects.
+ */
+export const WithActiveShares: Story = {
+  args: {
+    shares: mockShares,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    shares: mockShares,
+    isLoading: true,
+  },
+};

--- a/packages/ui-base/src/lib/credentials/CredentialTypeSelector.stories.tsx
+++ b/packages/ui-base/src/lib/credentials/CredentialTypeSelector.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import {
+  CredentialTypeSelector,
+  CredentialTypeSelectorProps,
+} from './CredentialTypeSelector';
+import { mockCredentialTypes } from './credentials-mocks';
+
+import './credentials.scss';
+
+/**
+ * The selector is controlled — the wrapper keeps the selection local so the
+ * story stays interactive in the Storybook canvas.
+ */
+const Wrap = ({
+  selectedType: initial,
+  ...props
+}: CredentialTypeSelectorProps) => {
+  const [selectedType, setSelectedType] = useState<string | null>(initial);
+  return (
+    <div style={{ width: '560px' }}>
+      <CredentialTypeSelector
+        {...props}
+        selectedType={selectedType}
+        onSelect={setSelectedType}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Credentials/CredentialTypeSelector',
+  component: Wrap,
+  parameters: { layout: 'centered' },
+  args: {
+    types: mockCredentialTypes,
+    selectedType: null,
+    onSelect: () => undefined,
+  },
+} satisfies Meta<typeof Wrap>;
+
+export default meta;
+
+type Story = StoryObj<typeof Wrap>;
+
+export const Normal: Story = {};
+
+export const WithSelection: Story = {
+  args: {
+    selectedType: 'github_token',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};
+
+/** No credential type registered on the backend. */
+export const Empty: Story = {
+  args: {
+    types: [],
+  },
+};

--- a/packages/ui-base/src/lib/credentials/CredentialsList.stories.tsx
+++ b/packages/ui-base/src/lib/credentials/CredentialsList.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CredentialsList } from './CredentialsList';
+import { mockCredentialTypes, mockCredentials } from './credentials-mocks';
+
+const noop = () => undefined;
+
+const meta = {
+  title: 'Credentials/CredentialsList',
+  component: CredentialsList,
+  parameters: { layout: 'centered' },
+  args: {
+    credentialTypes: mockCredentialTypes,
+    onAdd: noop,
+    onEdit: noop,
+    onDelete: noop,
+    onShare: noop,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '720px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CredentialsList>;
+
+export default meta;
+
+type Story = StoryObj<typeof CredentialsList>;
+
+export const Filled: Story = {
+  args: {
+    credentials: mockCredentials,
+  },
+};
+
+/** No credential yet — the empty state invites the user to add one. */
+export const Empty: Story = {
+  args: {
+    credentials: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    credentials: [],
+    loading: true,
+  },
+};

--- a/packages/ui-base/src/lib/credentials/credentials-mocks.ts
+++ b/packages/ui-base/src/lib/credentials/credentials-mocks.ts
@@ -1,0 +1,138 @@
+import {
+  TCredentialShare,
+  TCredentialSummary,
+  TCredentialType,
+} from '@holistix-forge/types';
+import type { Organization, Project } from './CredentialShareDialog';
+
+/**
+ * Deterministic fixtures shared by the credentials stories.
+ *
+ * Everything here is static on purpose: the stories are captured by the
+ * visual regression runner, so no `Date.now()`, no random ids.
+ */
+
+export const mockCredentialTypes: TCredentialType[] = [
+  {
+    credential_type: 'openai_api_key',
+    display_name: 'OpenAI API Key',
+    description: 'API key used by the AI modules',
+    icon_url: null,
+    validation_schema: null,
+    required_fields: ['value'],
+    module_name: 'ai',
+  },
+  {
+    credential_type: 'github_token',
+    display_name: 'GitHub Token',
+    description: 'Personal access token used to clone private repositories',
+    icon_url: null,
+    validation_schema: null,
+    required_fields: ['value'],
+    module_name: 'vcs',
+  },
+  {
+    credential_type: 'aws_access_key',
+    display_name: 'AWS Access Key',
+    description: 'Access key for S3 buckets and EC2 runners',
+    icon_url: null,
+    validation_schema: null,
+    required_fields: ['value'],
+    module_name: 'cloud',
+  },
+  {
+    credential_type: 'slack_webhook',
+    display_name: 'Slack Webhook',
+    description: 'Incoming webhook used for notifications',
+    icon_url: null,
+    validation_schema: null,
+    required_fields: ['value'],
+    module_name: 'communication',
+  },
+  {
+    credential_type: 'generic_secret',
+    display_name: 'Generic Secret',
+    description: null,
+    icon_url: null,
+    validation_schema: null,
+    required_fields: ['value'],
+    module_name: 'generic',
+  },
+];
+
+export const mockCredentials: TCredentialSummary[] = [
+  {
+    credential_id: 'cred-1',
+    user_id: 'user-1',
+    credential_type: 'openai_api_key',
+    name: 'OpenAI — production',
+    metadata: {},
+    created_at: '2026-01-08T09:00:00.000Z',
+    updated_at: '2026-01-08T09:00:00.000Z',
+    last_used_at: '2026-02-14T11:32:00.000Z',
+    is_shared: true,
+    share_scope: 'organization',
+  },
+  {
+    credential_id: 'cred-2',
+    user_id: 'user-1',
+    credential_type: 'github_token',
+    name: 'GitHub — CI bot',
+    metadata: {},
+    created_at: '2026-01-09T09:00:00.000Z',
+    updated_at: '2026-01-09T09:00:00.000Z',
+    last_used_at: null,
+    is_shared: false,
+    share_scope: null,
+  },
+  {
+    credential_id: 'cred-3',
+    user_id: 'user-1',
+    credential_type: 'aws_access_key',
+    name: 'AWS — staging',
+    metadata: {},
+    created_at: '2026-01-10T09:00:00.000Z',
+    updated_at: '2026-01-10T09:00:00.000Z',
+    last_used_at: '2026-01-30T08:05:00.000Z',
+    is_shared: false,
+    share_scope: null,
+  },
+];
+
+export const mockOrganizations: Organization[] = [
+  { organization_id: 'org-1', name: 'Holistix Forge' },
+  { organization_id: 'org-2', name: 'Acme Labs' },
+];
+
+export const mockProjects: Project[] = [
+  { project_id: 'proj-1', name: 'Data Platform', organization_id: 'org-1' },
+  { project_id: 'proj-2', name: 'Website', organization_id: 'org-1' },
+  { project_id: 'proj-3', name: 'Research', organization_id: 'org-2' },
+];
+
+export const mockShares: TCredentialShare[] = [
+  {
+    share_id: 'share-1',
+    credential_id: 'cred-1',
+    share_scope: 'organization',
+    organization_id: 'org-1',
+    project_id: null,
+    resource_id: null,
+    granted_by: 'user-1',
+    granted_at: '2026-01-15T10:00:00.000Z',
+    revoked_at: null,
+    is_active: true,
+  },
+  {
+    share_id: 'share-2',
+    credential_id: 'cred-1',
+    share_scope: 'project',
+    organization_id: 'org-1',
+    project_id: 'proj-1',
+    resource_id: null,
+    granted_by: 'user-1',
+    granted_at: '2026-01-16T10:00:00.000Z',
+    revoked_at: null,
+    is_active: true,
+  },
+];

--- a/packages/ui-base/src/lib/form/form-fields/color-picker.stories.tsx
+++ b/packages/ui-base/src/lib/form/form-fields/color-picker.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ColorPicker } from './color-picker';
+
+/**
+ * The palette itself lives in a Radix popover (rendered in a portal), so only
+ * the trigger swatch is captured by the screenshot suite. Click the swatch in
+ * the canvas to inspect the grid and the opacity slider.
+ */
+const meta = {
+  title: 'Forms/Fields/ColorPicker',
+  component: ColorPicker,
+  parameters: { layout: 'centered' },
+  args: {
+    buttonTitle: 'Pick a color',
+  },
+} satisfies Meta<typeof ColorPicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof ColorPicker>;
+
+export const Normal: Story = {
+  args: {
+    initialColor: '#0066FF',
+  },
+};
+
+/** With `withTransparency`, the popover also exposes an opacity slider. */
+export const WithTransparency: Story = {
+  args: {
+    initialColor: '#FF00FF',
+    initialOpacity: 40,
+    withTransparency: true,
+  },
+};

--- a/packages/ui-base/src/lib/form/form-fields/color-picker.tsx
+++ b/packages/ui-base/src/lib/form/form-fields/color-picker.tsx
@@ -30,7 +30,7 @@ export type ColorValue = {
   opacity: number;
 };
 
-interface ColorPickerProps {
+export interface ColorPickerProps {
   withTransparency?: boolean;
   initialColor?: string;
   initialOpacity?: number;

--- a/packages/ui-base/src/lib/form/form-fields/slider-fieldset.stories.tsx
+++ b/packages/ui-base/src/lib/form/form-fields/slider-fieldset.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { SliderFieldset, SliderFieldsetProps } from './slider-fieldset';
+
+/** The slider is controlled — hold the value in the story wrapper. */
+const Wrap = ({ value: initial, ...props }: SliderFieldsetProps) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <div style={{ width: '360px' }}>
+      <SliderFieldset {...props} value={value} onChange={setValue} />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Forms/Fields/Slider',
+  component: Wrap,
+  parameters: { layout: 'centered' },
+  args: {
+    name: 'cpu',
+    label: 'CPU',
+    value: 40,
+  },
+} satisfies Meta<typeof Wrap>;
+
+export default meta;
+
+type Story = StoryObj<typeof Wrap>;
+
+export const Normal: Story = {};
+
+export const WithSuffix: Story = {
+  args: {
+    name: 'memory',
+    label: 'Memory',
+    value: 8,
+    min: 1,
+    max: 64,
+    valueSuffix: 'GB',
+  },
+};
+
+export const Optional: Story = {
+  args: {
+    required: false,
+  },
+};
+
+export const WithoutValue: Story = {
+  args: {
+    displayValue: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/packages/ui-base/src/lib/indicators/loading-dots.stories.tsx
+++ b/packages/ui-base/src/lib/indicators/loading-dots.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { LoadingDots } from './loading-dots';
+
+const meta = {
+  title: 'Basics/LoadingDots',
+  component: LoadingDots,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof LoadingDots>;
+
+export default meta;
+
+type Story = StoryObj<typeof LoadingDots>;
+
+export const Normal: Story = {};
+
+/** Inline inside a sentence, which is how it is used in the chat modules. */
+export const Inline: Story = {
+  render: () => (
+    <span>
+      Waiting for the kernel
+      <LoadingDots />
+    </span>
+  ),
+};

--- a/packages/ui-base/src/lib/permissions-page/permissions-mocks.ts
+++ b/packages/ui-base/src/lib/permissions-page/permissions-mocks.ts
@@ -1,0 +1,90 @@
+import type { Role } from './user-role-editor';
+import type { OrgMember, UserRoleAssignment } from './users-tab';
+
+/**
+ * Deterministic fixtures shared by the permissions-page stories.
+ * Kept static (no random ids, no `Date.now()`) so the visual regression
+ * snapshots stay stable.
+ */
+
+export const mockRoles: Role[] = [
+  {
+    role_id: 'role-owner',
+    role_name: 'org:owner',
+    display_name: 'Organization Owner',
+    description: 'Full access to everything',
+    permissions: ['*'],
+    scope: 'org',
+    system: true,
+    immutable: true,
+  },
+  {
+    role_id: 'role-admin',
+    role_name: 'org:admin',
+    display_name: 'Organization Admin',
+    description: 'Administrative access',
+    permissions: ['org:*:admin', 'project:*:create', 'project:*:admin'],
+    scope: 'org',
+    system: true,
+    immutable: true,
+  },
+  {
+    role_id: 'role-developer',
+    role_name: 'project-developer',
+    display_name: 'Project Developer',
+    description: 'Can read and write projects',
+    permissions: ['project:*:read', 'project:*:write', 'container:*:create'],
+    scope: 'project',
+    system: false,
+    immutable: false,
+  },
+  {
+    role_id: 'role-viewer',
+    role_name: 'project-viewer',
+    display_name: 'Project Viewer',
+    description: 'Read-only access to projects',
+    permissions: ['project:*:read'],
+    scope: 'project',
+    system: false,
+    immutable: false,
+  },
+];
+
+export const mockMembers: OrgMember[] = [
+  {
+    user_id: 'user-1',
+    username: 'claude-test',
+    email: 'claude@test.local',
+    added_at: '2026-01-05T09:00:00.000Z',
+  },
+  {
+    user_id: 'user-2',
+    username: 'alice',
+    email: 'alice@example.com',
+    added_at: '2026-01-12T09:00:00.000Z',
+  },
+  {
+    user_id: 'user-3',
+    username: 'bob',
+    email: 'bob@example.com',
+    added_at: '2026-01-20T09:00:00.000Z',
+  },
+];
+
+export const mockUserRoles: { [user_id: string]: UserRoleAssignment } = {
+  'user-1': {
+    user_id: 'user-1',
+    org_roles: [mockRoles[0]],
+    project_roles: {},
+  },
+  'user-2': {
+    user_id: 'user-2',
+    org_roles: [mockRoles[1]],
+    project_roles: { 'proj-1': [mockRoles[2]] },
+  },
+  'user-3': {
+    user_id: 'user-3',
+    org_roles: [],
+    project_roles: { 'proj-1': [mockRoles[3]] },
+  },
+};

--- a/packages/ui-base/src/lib/permissions-page/permissions-page.stories.tsx
+++ b/packages/ui-base/src/lib/permissions-page/permissions-page.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { PermissionsPage } from './permissions-page';
+import { mockMembers, mockRoles, mockUserRoles } from './permissions-mocks';
+
+const asyncNoop = async () => undefined;
+
+const meta = {
+  title: 'Users/PermissionsPage',
+  component: PermissionsPage,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    roles: mockRoles,
+    rolesLoading: false,
+    members: mockMembers,
+    membersLoading: false,
+    userRoles: mockUserRoles,
+    userRolesLoading: false,
+    onCreateRole: asyncNoop,
+    onUpdateRole: asyncNoop,
+    onDeleteRole: asyncNoop,
+    onAssignRole: asyncNoop,
+    onRemoveRole: asyncNoop,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '760px', width: '1100px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PermissionsPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof PermissionsPage>;
+
+export const RolesTabDefault: Story = {};
+
+export const UsersTabDefault: Story = {
+  args: {
+    defaultTab: 'users',
+  },
+};
+
+/** A member without `org:admin` sees the page but cannot mutate anything. */
+export const ReadOnly: Story = {
+  args: {
+    readonly: true,
+    defaultTab: 'users',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    roles: [],
+    rolesLoading: true,
+    members: [],
+    membersLoading: true,
+    userRoles: {},
+    userRolesLoading: true,
+  },
+};

--- a/packages/ui-base/src/lib/permissions-page/permissions-page.tsx
+++ b/packages/ui-base/src/lib/permissions-page/permissions-page.tsx
@@ -24,7 +24,9 @@ export interface PermissionsPageProps {
   defaultTab?: 'roles' | 'users';
 
   // Role management callbacks
-  onCreateRole: (role: Omit<Role, 'role_id' | 'system' | 'immutable'>) => Promise<void>;
+  onCreateRole: (
+    role: Omit<Role, 'role_id' | 'system' | 'immutable'>
+  ) => Promise<void>;
   onUpdateRole: (
     roleId: string,
     updates: Partial<Pick<Role, 'display_name' | 'description' | 'permissions'>>
@@ -38,7 +40,11 @@ export interface PermissionsPageProps {
     scope: 'org' | 'project',
     project_id?: string
   ) => Promise<void>;
-  onRemoveRole: (user_id: string, role_id: string, project_id?: string) => Promise<void>;
+  onRemoveRole: (
+    user_id: string,
+    role_id: string,
+    project_id?: string
+  ) => Promise<void>;
 }
 
 export const PermissionsPage = ({
@@ -70,10 +76,16 @@ export const PermissionsPage = ({
     <div className="permissions-page">
       <header className="page-header">
         <h1>Organization Permissions</h1>
-        <p className="subtitle">Manage roles and user access for your organization</p>
+        <p className="subtitle">
+          Manage roles and user access for your organization
+        </p>
       </header>
 
-      <Tabs.Root className="tabs-root" value={activeTab} onValueChange={setActiveTab}>
+      <Tabs.Root
+        className="tabs-root"
+        value={activeTab}
+        onValueChange={setActiveTab}
+      >
         <Tabs.List className="tabs-list">
           <Tabs.Trigger className="tabs-trigger" value="roles">
             Roles

--- a/packages/ui-base/src/lib/permissions-page/roles-tab.stories.tsx
+++ b/packages/ui-base/src/lib/permissions-page/roles-tab.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RolesTab } from './roles-tab';
+import { mockRoles } from './permissions-mocks';
+
+import './permissions-page.scss';
+
+const asyncNoop = async () => undefined;
+
+const meta = {
+  title: 'Users/PermissionsPage/RolesTab',
+  component: RolesTab,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    roles: mockRoles,
+    loading: false,
+    onCreateRole: asyncNoop,
+    onUpdateRole: asyncNoop,
+    onDeleteRole: asyncNoop,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '640px', width: '1000px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RolesTab>;
+
+export default meta;
+
+type Story = StoryObj<typeof RolesTab>;
+
+export const Normal: Story = {};
+
+export const ReadOnly: Story = {
+  args: { readonly: true },
+};
+
+export const Loading: Story = {
+  args: { roles: [], loading: true },
+};

--- a/packages/ui-base/src/lib/permissions-page/user-role-editor.stories.tsx
+++ b/packages/ui-base/src/lib/permissions-page/user-role-editor.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { UserRoleEditor } from './user-role-editor';
+import { mockRoles } from './permissions-mocks';
+
+import './permissions-page.scss';
+
+const asyncNoop = async () => undefined;
+
+const meta = {
+  title: 'Users/PermissionsPage/UserRoleEditor',
+  component: UserRoleEditor,
+  parameters: { layout: 'centered' },
+  args: {
+    user_id: 'user-2',
+    username: 'alice',
+    currentRoles: [mockRoles[1]],
+    availableRoles: mockRoles,
+    loading: false,
+    onAssignRole: asyncNoop,
+    onRemoveRole: asyncNoop,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '620px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof UserRoleEditor>;
+
+export default meta;
+
+type Story = StoryObj<typeof UserRoleEditor>;
+
+export const Normal: Story = {};
+
+/** `org:owner` is immutable — its badge has no remove button. */
+export const ImmutableRole: Story = {
+  args: {
+    user_id: 'user-1',
+    username: 'claude-test',
+    currentRoles: [mockRoles[0]],
+  },
+};
+
+export const NoRoleAssigned: Story = {
+  args: {
+    user_id: 'user-3',
+    username: 'bob',
+    currentRoles: [],
+  },
+};
+
+export const ReadOnly: Story = {
+  args: { readonly: true },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};

--- a/packages/ui-base/src/lib/permissions-page/user-role-editor.tsx
+++ b/packages/ui-base/src/lib/permissions-page/user-role-editor.tsx
@@ -23,7 +23,11 @@ export interface UserRoleEditorProps {
   availableRoles: Role[];
   loading: boolean;
   readonly?: boolean;
-  onAssignRole: (role_id: string, scope: 'org' | 'project', project_id?: string) => Promise<void>;
+  onAssignRole: (
+    role_id: string,
+    scope: 'org' | 'project',
+    project_id?: string
+  ) => Promise<void>;
   onRemoveRole: (role_id: string, project_id?: string) => Promise<void>;
 }
 
@@ -53,7 +57,10 @@ const RoleBadge = ({
       )}
       <Popover.Root open={showPermissions} onOpenChange={setShowPermissions}>
         <Popover.Trigger asChild>
-          <button className="info-btn" aria-label={`View permissions for ${role.display_name}`}>
+          <button
+            className="info-btn"
+            aria-label={`View permissions for ${role.display_name}`}
+          >
             <InfoCircledIcon />
           </button>
         </Popover.Trigger>
@@ -76,7 +83,10 @@ const RoleBadge = ({
                     ))}
                   </ul>
                 </ScrollArea.Viewport>
-                <ScrollArea.Scrollbar className="scroll-area-scrollbar" orientation="vertical">
+                <ScrollArea.Scrollbar
+                  className="scroll-area-scrollbar"
+                  orientation="vertical"
+                >
                   <ScrollArea.Thumb className="scroll-area-thumb" />
                 </ScrollArea.Scrollbar>
               </ScrollArea.Root>
@@ -101,16 +111,13 @@ export const UserRoleEditor = ({
 }: UserRoleEditorProps) => {
   const [selectedRoleId, setSelectedRoleId] = useState<string>('');
 
-  const assignAction = useAction(
-    async () => {
-      if (!selectedRoleId) return;
-      const role = availableRoles.find((r) => r.role_id === selectedRoleId);
-      if (!role) return;
-      await onAssignRole(selectedRoleId, role.scope);
-      setSelectedRoleId('');
-    },
-    [selectedRoleId, onAssignRole, availableRoles]
-  );
+  const assignAction = useAction(async () => {
+    if (!selectedRoleId) return;
+    const role = availableRoles.find((r) => r.role_id === selectedRoleId);
+    if (!role) return;
+    await onAssignRole(selectedRoleId, role.scope);
+    setSelectedRoleId('');
+  }, [selectedRoleId, onAssignRole, availableRoles]);
 
   // Filter out already assigned roles
   const assignableRoles = availableRoles.filter(
@@ -181,7 +188,9 @@ export const UserRoleEditor = ({
       )}
 
       {!readonly && assignableRoles.length === 0 && currentRoles.length > 0 && (
-        <p className="info-message">All available roles are already assigned.</p>
+        <p className="info-message">
+          All available roles are already assigned.
+        </p>
       )}
     </div>
   );

--- a/packages/ui-base/src/lib/permissions-page/users-tab.stories.tsx
+++ b/packages/ui-base/src/lib/permissions-page/users-tab.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { UsersTab } from './users-tab';
+import { mockMembers, mockRoles, mockUserRoles } from './permissions-mocks';
+
+import './permissions-page.scss';
+
+const asyncNoop = async () => undefined;
+
+const getUserRoles = (user_id: string) =>
+  mockUserRoles[user_id]?.org_roles ?? [];
+
+const meta = {
+  title: 'Users/PermissionsPage/UsersTab',
+  component: UsersTab,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    members: mockMembers,
+    membersLoading: false,
+    roles: mockRoles,
+    rolesLoading: false,
+    getUserRoles,
+    onAssignRole: asyncNoop,
+    onRemoveRole: asyncNoop,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '640px', width: '1000px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof UsersTab>;
+
+export default meta;
+
+type Story = StoryObj<typeof UsersTab>;
+
+export const Normal: Story = {};
+
+export const ReadOnly: Story = {
+  args: { readonly: true },
+};
+
+/** The organization has no member other than the owner. */
+export const SingleMember: Story = {
+  args: { members: [mockMembers[0]] },
+};
+
+export const Loading: Story = {
+  args: {
+    members: [],
+    membersLoading: true,
+    roles: [],
+    rolesLoading: true,
+  },
+};

--- a/packages/ui-base/src/lib/permissions-page/users-tab.tsx
+++ b/packages/ui-base/src/lib/permissions-page/users-tab.tsx
@@ -23,8 +23,17 @@ export interface UsersTabProps {
   rolesLoading: boolean;
   getUserRoles: (user_id: string) => Role[];
   readonly?: boolean;
-  onAssignRole: (user_id: string, role_id: string, scope: 'org' | 'project', project_id?: string) => Promise<void>;
-  onRemoveRole: (user_id: string, role_id: string, project_id?: string) => Promise<void>;
+  onAssignRole: (
+    user_id: string,
+    role_id: string,
+    scope: 'org' | 'project',
+    project_id?: string
+  ) => Promise<void>;
+  onRemoveRole: (
+    user_id: string,
+    role_id: string,
+    project_id?: string
+  ) => Promise<void>;
 }
 
 const UserListItem = ({
@@ -62,7 +71,9 @@ const UserListItem = ({
         {roles.length === 0 ? (
           <span className="no-roles">(no roles)</span>
         ) : (
-          <span className="role-count">{roles.length} role{roles.length !== 1 ? 's' : ''}</span>
+          <span className="role-count">
+            {roles.length} role{roles.length !== 1 ? 's' : ''}
+          </span>
         )}
       </div>
     </div>
@@ -126,7 +137,9 @@ export const UsersTab = ({
       <div className="panel-users">
         <header>
           <h3>Organization Members</h3>
-          <p className="member-count">{members.length} member{members.length !== 1 ? 's' : ''}</p>
+          <p className="member-count">
+            {members.length} member{members.length !== 1 ? 's' : ''}
+          </p>
         </header>
 
         <div className="search-box">
@@ -144,7 +157,9 @@ export const UsersTab = ({
             <div className="user-list">
               {filteredMembers.length === 0 ? (
                 <p className="empty-state">
-                  {searchQuery ? 'No members match your search.' : 'No members in organization.'}
+                  {searchQuery
+                    ? 'No members match your search.'
+                    : 'No members in organization.'}
                 </p>
               ) : (
                 filteredMembers.map((member) => (
@@ -159,7 +174,10 @@ export const UsersTab = ({
               )}
             </div>
           </ScrollArea.Viewport>
-          <ScrollArea.Scrollbar className="scroll-area-scrollbar" orientation="vertical">
+          <ScrollArea.Scrollbar
+            className="scroll-area-scrollbar"
+            orientation="vertical"
+          >
             <ScrollArea.Thumb className="scroll-area-thumb" />
           </ScrollArea.Scrollbar>
         </ScrollArea.Root>

--- a/packages/ui-base/src/lib/tags/tags.stories.tsx
+++ b/packages/ui-base/src/lib/tags/tags.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Tag, TagsBar, TagsBarProps } from './tags';
+
+/** Fixed colors — `randomColor()` would make the snapshots flaky. */
+const baseTags: Tag[] = [
+  { text: 'python', color: '#7AC0FF' },
+  { text: 'dataset', color: '#FFB86C' },
+  { text: 'ml', color: '#A5F3B0' },
+];
+
+const manyTags: Tag[] = [
+  ...baseTags,
+  { text: 'production', color: '#FF7AC0' },
+  { text: 'archived', color: '#C0A5FF' },
+  { text: 'needs-review', color: '#FFE066' },
+  { text: 'experimental', color: '#7AFFE0' },
+];
+
+/** `TagsBar` is uncontrolled from the outside: keep the list in the story. */
+const Wrap = ({
+  tags: initial = [],
+  editable,
+}: TagsBarProps & { editable?: boolean }) => {
+  const [tags, setTags] = useState<Tag[]>(initial);
+
+  const props: TagsBarProps = {
+    tags,
+    addTag: (tag) => setTags((prev) => [...prev, tag]),
+  };
+
+  if (editable) {
+    props.editTag = (index, newText) =>
+      setTags((prev) =>
+        prev.map((t, i) => (i === index ? { ...t, text: newText } : t))
+      );
+  }
+
+  return (
+    <div style={{ width: '320px' }}>
+      <TagsBar {...props} />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Basics/Tags',
+  component: Wrap,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Wrap>;
+
+export default meta;
+
+type Story = StoryObj<typeof Wrap>;
+
+export const Normal: Story = {
+  args: { tags: baseTags },
+};
+
+/** No tag yet: only the `+` button is shown. */
+export const Empty: Story = {
+  args: { tags: [] },
+};
+
+/** Click a tag to rename it inline. */
+export const Editable: Story = {
+  args: { tags: baseTags, editable: true },
+};
+
+/** More tags than the bar can fit — the overflow collapses behind `...`. */
+export const Overflowing: Story = {
+  args: { tags: manyTags },
+};

--- a/packages/ui-base/src/lib/users/user-list-item.stories.tsx
+++ b/packages/ui-base/src/lib/users/user-list-item.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TCollaborator } from '@holistix-forge/types';
+
+import { UserListItem } from './user-list-item';
+import { ButtonBase } from '../buttons/buttonBase';
+
+/** Static collaborators — no random avatar, so the snapshots stay stable. */
+const owner: TCollaborator = {
+  user_id: 'user-1',
+  username: 'github:codeMaster99',
+  firstname: 'Alice',
+  lastname: 'Johnson',
+  picture: null,
+  scope: ['org:admin'],
+  is_owner: true,
+};
+
+const member: TCollaborator = {
+  user_id: 'user-2',
+  username: 'local:bob',
+  firstname: 'Bob',
+  lastname: 'Smith',
+  picture: null,
+  scope: ['project:read'],
+  is_owner: false,
+};
+
+const meta = {
+  title: 'Users/UserListItem',
+  component: UserListItem,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '420px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof UserListItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof UserListItem>;
+
+export const Normal: Story = {
+  args: { collaborator: owner },
+};
+
+/** With an `onClick`, the row becomes a button (role + keyboard handling). */
+export const Clickable: Story = {
+  args: {
+    collaborator: member,
+    onClick: () => undefined,
+  },
+};
+
+/** Trailing actions are rendered through `children`. */
+export const WithActions: Story = {
+  args: {
+    collaborator: member,
+    children: <ButtonBase text="Remove" callback={() => undefined} />,
+  },
+};

--- a/packages/ui-views/.storybook/test-runner.js
+++ b/packages/ui-views/.storybook/test-runner.js
@@ -25,6 +25,15 @@ async function waitUntilReady(page) {
 }
 
 module.exports = {
+  /**
+   * Stories tagged `no-visual-test` are skipped by the screenshot suite.
+   * Use it for stories whose rendering is time- or randomness-dependent
+   * (live counters, animated indicators) — they would diff on every run.
+   */
+  tags: {
+    skip: ['no-visual-test'],
+  },
+
   setup() {
     expect.extend({ toMatchImageSnapshot });
   },

--- a/packages/ui-views/src/lib/form/form-new-organization/new-organization.stories.tsx
+++ b/packages/ui-views/src/lib/form/form-new-organization/new-organization.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useAction, DialogControlled } from '@holistix-forge/ui-base';
+import { NewOrganizationFormData } from '@holistix-forge/frontend-data';
+
+import { NewOrganizationForm } from './new-organization';
+
+//
+
+const StoryWrapper = ({ failing }: { failing?: boolean }) => {
+  const action = useAction<NewOrganizationFormData>(
+    () =>
+      failing
+        ? Promise.reject(new Error('An organization with that name exists'))
+        : Promise.resolve(),
+    [failing]
+  );
+  return (
+    <DialogControlled
+      title="New Organization"
+      description="Choose an organization name"
+      open={true}
+      onOpenChange={() => null}
+    >
+      <NewOrganizationForm action={action} />
+    </DialogControlled>
+  );
+};
+
+//
+
+const meta = {
+  title: 'Forms/NewOrganization',
+  component: StoryWrapper,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+} satisfies Meta<typeof StoryWrapper>;
+
+export default meta;
+
+type Story = StoryObj<typeof StoryWrapper>;
+
+export const Normal: Story = {
+  args: {},
+};
+
+/** Submitting surfaces the backend error through `FormErrors`. */
+export const Failing: Story = {
+  args: { failing: true },
+};

--- a/packages/ui-views/src/lib/form/form-new-organization/new-organization.tsx
+++ b/packages/ui-views/src/lib/form/form-new-organization/new-organization.tsx
@@ -42,4 +42,3 @@ export const NewOrganizationForm = ({
     </>
   );
 };
-

--- a/packages/ui-views/src/lib/mvp-ui-view/components/server-stack.stories.tsx
+++ b/packages/ui-views/src/lib/mvp-ui-view/components/server-stack.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ServerStack } from './server-stack';
+
+//
+
+/** Stand-in for a resource card: the stack only lays its children out. */
+const Card = ({ name }: { name: string }) => (
+  <div
+    style={{
+      width: '400px',
+      height: '202px',
+      borderRadius: '8px',
+      background: 'var(--color-bg-elevated, rgba(255,255,255,0.06))',
+      border: '1px solid rgba(255,255,255,0.15)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: 'white',
+      fontSize: '14px',
+    }}
+  >
+    {name}
+  </div>
+);
+
+const StoryWrapper = ({ count }: { count: number }) => (
+  <div style={{ width: '1000px' }}>
+    <ServerStack onNewServerClick={() => undefined}>
+      {Array.from({ length: count }, (_, i) => (
+        <Card key={`server-${i}`} name={`server-${i}`} />
+      ))}
+    </ServerStack>
+  </div>
+);
+
+//
+
+const meta = {
+  title: 'Mvp/Components/server-stack',
+  component: StoryWrapper,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+} satisfies Meta<typeof StoryWrapper>;
+
+export default meta;
+
+type Story = StoryObj<typeof StoryWrapper>;
+
+/** Only the "add resource" placeholder. */
+export const Empty: Story = {
+  args: { count: 0 },
+};
+
+export const Normal: Story = {
+  args: { count: 3 },
+};


### PR DESCRIPTION
## Context

The Storybook setup had not been maintained since **2026-02-02** (`76cabd8f` — *improve screenshot test-runner and regenerate baselines*). The only later touch (`4e7a33db`, March) was collateral from an auth refactor. Six-month gap.

## What the audit found

**1. The visual regression suite was dead, not drifting.** Every suite failed to *start*: `Test suite failed to run — unknown variant 'es2023'`. `@swc/core` was pinned `~1.5.7` (mid-2024) while `@swc/jest` targets `es2023` on Node ≥ 18. CI runs Node 24, and the `visual-regression` job is non-blocking, so it had been silently testing nothing for months.

**2. ESLint was linting generated bundles.** `storybook-static/` was missing from `ignores` — `npm run lint` after a local build produced thousands of errors on minified code.

**3. Config drift.** 9 module packages lacked `@storybook/addon-interactions` while 4 of them use `play()`.

**4. Coverage gap.** RBAC (Jan 26) and the Credentials Wallet (Jan 8–12) shipped with no stories at all. 155 baselines committed for 196 stories → **41 stories (21%) never captured**; `airtable` and `excalidraw` had zero.

## Changes

| Area | Change |
| --- | --- |
| Toolchain | `@swc/core` `~1.5.7` → `~1.15.47` — all 11 suites execute again, 251 stories render, zero crash |
| Lint | `eslint.config.cjs` ignores `storybook-static`, `__screenshots__`, `__diff_output__` |
| Config | 11 `main.ts` aligned on the same addon list |
| Config | `no-visual-test` tag added to the 11 `test-runner.js` for non-deterministic stories |
| Stories | **+17 files, +55 stories** with deterministic fixtures in `*-mocks.ts` |
| Docs | New `doc/guides/STORYBOOK.md`, linked from `doc/README.md` and `TESTING_GUIDE.md` |

New stories — `ui-base`: Credentials (Card, Form, TypeSelector, List, ShareDialog), PermissionsPage, RolesTab, UsersTab, UserRoleEditor, UserListItem, TagsBar, ColorPicker, SliderFieldset, LoadingDots, Countdown. `ui-views`: NewOrganizationForm, ServerStack.

`CountdownProps` and `ColorPickerProps` are now exported (required by `satisfies Meta<>`, otherwise `TS4023`).

## Validation

- `typecheck` ✅ · `lint` **0 errors** ✅ · `test` 62/62 ui-base ✅
- 11/11 Storybooks build ✅
- Full screenshot suite runs across all 11 packages, **zero "Test suite failed to run"** (previously 100% failed)

Note: `reducers` and `collab-engine` fail `typecheck` locally when dependency `dist/` output is absent (module resolution). CI builds before typechecking, so this does not occur there — nothing broken, nothing changed.

## Bonus: a latent CI bug this surfaced

The `Comment on PR with visual regression results` step interpolated `steps.visual-tests.outputs.DIFF_FILES` textually into a JS template literal. The shell wraps each diff filename in backticks, so the first one closes the literal — `SyntaxError: Unexpected identifier 'forms'`, whole job red.

It was latent: before the `@swc/core` fix, `test-storybook` aborted before producing any diff, `DIFF_FILES` was always empty, and the script happened to parse. The first real diff triggers it. Fixed in `d4e27215` by passing the values through `env:` and reading `process.env` — data, never code, which also removes the injection surface.

## ⚠️ Follow-up required: regenerate baselines

**No baseline PNGs are included in this PR, on purpose.** They are rendered on Linux to match the `ubuntu-24.04` runner; regenerating them from a macOS host differs by 3–6% per story **on glyph antialiasing alone** — identical layout and colors. Committing macOS renders would permanently poison the CI comparison.

From the Linux dev container or CI:

```bash
npm run test:visual:update
```

That covers the 55 new stories **and** the 41 stories that never had a baseline. Until then, the (non-blocking) `visual-regression` job will report missing snapshots in its PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

