### PR TITLE
fix: stop the frontend render loop and restore missing gateway backends

### DIFF
--- a/packages/app-frontend/src/app/modules.ts
+++ b/packages/app-frontend/src/app/modules.ts
@@ -28,30 +28,37 @@ import { moduleFrontend as vscodeFrontend } from '@holistix-forge/vscode/fronten
  *
  * @returns Array of modules with config keys
  */
+const ALL_MODULES: {
+  module: TModule<never, object>;
+  configKey?: 'collab' | 'reducers';
+}[] = [
+  // Collab module - needs multi-project registry config
+  { module: collabFrontend, configKey: 'collab' },
+
+  // Reducers module - needs gateway fetch config
+  { module: reducersFrontend, configKey: 'reducers' },
+
+  // Core modules - no special config
+  { module: coreFrontend },
+  { module: spaceFrontend },
+  { module: tabsFrontend },
+
+  // Feature modules - no special config
+  { module: userContainersFrontend },
+  { module: notionFrontend },
+  { module: airtableFrontend },
+  { module: excalidrawFrontend },
+  { module: gatewayFrontend },
+  { module: socialsFrontend },
+  { module: chatsFrontend },
+  { module: vscodeFrontend },
+];
+
 export function getAllModules(): {
   module: TModule<never, object>;
   configKey?: 'collab' | 'reducers';
 }[] {
-  return [
-    // Collab module - needs multi-project registry config
-    { module: collabFrontend, configKey: 'collab' },
-
-    // Reducers module - needs gateway fetch config
-    { module: reducersFrontend, configKey: 'reducers' },
-
-    // Core modules - no special config
-    { module: coreFrontend },
-    { module: spaceFrontend },
-    { module: tabsFrontend },
-
-    // Feature modules - no special config
-    { module: userContainersFrontend },
-    { module: notionFrontend },
-    { module: airtableFrontend },
-    { module: excalidrawFrontend },
-    { module: gatewayFrontend },
-    { module: socialsFrontend },
-    { module: chatsFrontend },
-    { module: vscodeFrontend },
-  ];
+  // The same array every time, on purpose: callers pass this straight into a
+  // render and a fresh array would invalidate the memo that loads the modules.
+  return ALL_MODULES;
 }

--- a/packages/app-frontend/src/app/pages/project/project-wrapper.tsx
+++ b/packages/app-frontend/src/app/pages/project/project-wrapper.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 
@@ -111,6 +111,27 @@ export const ProjectWrapper = ({ children }: { children: ReactNode }) => {
     error,
   } = useQueryProjectByName(owner || '', project_name || '');
 
+  // Extract user info for ModuleDataProvider's collab config. Memoized, and
+  // computed before the early returns below so the hook order stays fixed:
+  // this object is a dependency of the memo that loads every frontend module,
+  // and rebuilding it on each render reloaded them all — which handed the
+  // whiteboard a new node component type and remounted every node.
+  // Color is generated from the username hash in collab-config.ts.
+  const user = currentUserData?.user;
+  const user_id = user && 'user_id' in user ? user.user_id : null;
+  const username =
+    user && 'username' in user ? user.username || user.email : undefined;
+  const userInfo = useMemo(
+    () =>
+      user_id
+        ? { user_id, username: username || 'User' }
+        : {
+            user_id: '00000000-0000-0000-0000-000000000001',
+            username: 'Guest User',
+          },
+    [user_id, username]
+  );
+
   // Check for invalid URL first
   if (!owner || !project_name) {
     return <ProjectError message="Invalid project URL" />;
@@ -160,20 +181,6 @@ export const ProjectWrapper = ({ children }: { children: ReactNode }) => {
   }
 
   // Success - render with data providers
-  // Extract user info from useCurrentUser to pass to ModuleDataProvider for collab config
-  // At this point currentUserData is guaranteed to exist because we checked userStatus above
-  // Color will be generated from username hash in collab-config.ts
-  const userInfo = currentUserData?.user?.user_id
-    ? {
-        user_id: currentUserData.user.user_id,
-        username:
-          currentUserData.user.username || currentUserData.user.email || 'User',
-      }
-    : {
-        user_id: '00000000-0000-0000-0000-000000000001',
-        username: 'Guest User',
-      };
-
   return (
     <ModuleDataProvider
       organization_id={project.organization_id}

--- a/packages/app-gateway/src/config/modules.ts
+++ b/packages/app-gateway/src/config/modules.ts
@@ -12,6 +12,11 @@ import { moduleBackend as jupyterBackend } from '@holistix-forge/jupyter';
 import { moduleBackend as n8nBackend } from '@holistix-forge/n8n';
 import { moduleBackend as pgadmin4Backend } from '@holistix-forge/pgadmin4';
 import { moduleBackend as vscodeBackend } from '@holistix-forge/vscode';
+import { moduleBackend as notionBackend } from '@holistix-forge/notion';
+import { moduleBackend as airtableBackend } from '@holistix-forge/airtable';
+import { moduleBackend as excalidrawBackend } from '@holistix-forge/excalidraw';
+import { moduleBackend as socialsBackend } from '@holistix-forge/socials';
+import { moduleBackend as chatsBackend } from '@holistix-forge/chats';
 import { moduleBackend as gatewayBackend } from '../module/module';
 import type {
   PermissionManager,
@@ -93,6 +98,14 @@ export function createBackendModulesConfig(
   // 6. tabs (depends on collab, reducers) - handles project:init
   // 7. user-containers (depends on core-graph, collab, reducers, gateway)
   // 8. Container image modules (depend on user-containers)
+  // 9. Content modules (depend on core-graph, collab, reducers)
+  //
+  // These must be here, not only in the frontend. A module whose menu entry
+  // dispatches its own event — `chats:new-chat` rather than `core:new-node`
+  // directly — has nothing to handle it if its backend is absent: the click
+  // registers, the event goes nowhere, and no node is ever created, with no
+  // error anywhere. Excalidraw masked this by dispatching `core:new-node`
+  // itself, which core-graph handles regardless.
   return [
     { module: collabBackend, config: collabConfig },
     { module: reducersBackend, config: {} },
@@ -105,5 +118,10 @@ export function createBackendModulesConfig(
     { module: n8nBackend, config: {} },
     { module: pgadmin4Backend, config: {} },
     { module: vscodeBackend, config: {} },
+    { module: notionBackend, config: {} },
+    { module: airtableBackend, config: {} },
+    { module: excalidrawBackend, config: {} },
+    { module: socialsBackend, config: {} },
+    { module: chatsBackend, config: {} },
   ];
 }

--- a/packages/app-gateway/tsconfig.app.json
+++ b/packages/app-gateway/tsconfig.app.json
@@ -42,6 +42,21 @@
       "path": "../modules/gateway/tsconfig.lib.json"
     },
     {
+      "path": "../modules/chats/tsconfig.lib.json"
+    },
+    {
+      "path": "../modules/socials/tsconfig.lib.json"
+    },
+    {
+      "path": "../modules/excalidraw/tsconfig.lib.json"
+    },
+    {
+      "path": "../modules/airtable/tsconfig.lib.json"
+    },
+    {
+      "path": "../modules/notion/tsconfig.lib.json"
+    },
+    {
       "path": "../modules/vscode/tsconfig.lib.json"
     },
     {

--- a/packages/app-gateway/tsconfig.json
+++ b/packages/app-gateway/tsconfig.json
@@ -25,6 +25,21 @@
       "path": "../modules/gateway"
     },
     {
+      "path": "../modules/chats"
+    },
+    {
+      "path": "../modules/socials"
+    },
+    {
+      "path": "../modules/excalidraw"
+    },
+    {
+      "path": "../modules/airtable"
+    },
+    {
+      "path": "../modules/notion"
+    },
+    {
       "path": "../modules/vscode"
     },
     {

--- a/packages/frontend-data/src/lib/modules/module-data-provider.tsx
+++ b/packages/frontend-data/src/lib/modules/module-data-provider.tsx
@@ -68,6 +68,11 @@ export const ModuleDataProvider = ({
     }
   }, [gateway_hostname, organization_id, ganymedeApi]);
 
+  // Identify the module set by name+order rather than by array identity.
+  const moduleSignature = modules
+    .map(({ module, configKey }) => `${module.name}@${configKey ?? ''}`)
+    .join(',');
+
   // Create module configs and load modules when gateway is available
   // Memoized to avoid reloading unless gateway changes
   const moduleExports = useMemo(() => {
@@ -93,7 +98,19 @@ export const ModuleDataProvider = ({
     }));
 
     return loadModules(modulesWithConfig);
-  }, [gateway_hostname, organization_id, ganymedeApi, userInfo, modules]);
+    // Depend on the *values* that matter, not on the identity of `userInfo`
+    // and `modules`. Callers build both inline, so keying the memo on their
+    // references re-ran `loadModules` on every render: each pass produced a
+    // fresh set of module exports, which gave the whiteboard a new node
+    // component type and remounted every node in the project on every render.
+  }, [
+    gateway_hostname,
+    organization_id,
+    ganymedeApi,
+    userInfo.user_id,
+    userInfo.username,
+    moduleSignature,
+  ]);
 
   // Loading state - waiting for gateway info
   if (status === 'pending') {

--- a/packages/frontend-data/src/lib/queries.ts
+++ b/packages/frontend-data/src/lib/queries.ts
@@ -316,6 +316,13 @@ export const useCurrentUser = () => {
       }) as Promise<{
         user: CurrentUserDetails | { user_id: null };
       }>,
+    // Who is logged in does not change on its own — every transition that
+    // does change it (login, logout, TOTP, password reset) invalidates this
+    // key explicitly. Without a staleTime this query refetched on every
+    // mount, so a component that remounts in a loop turned into a /me flood
+    // that exhausted the API rate limit and re-rendered every other consumer
+    // of this hook, which kept the loop fed.
+    staleTime: 5 * 60 * 1000,
   });
 };
 

--- a/packages/modules/chats/src/lib/components/node-chat-anchor/node-chat-anchor.tsx
+++ b/packages/modules/chats/src/lib/components/node-chat-anchor/node-chat-anchor.tsx
@@ -32,7 +32,9 @@ export const NodeChatAnchor = ({ node }: { node: TGraphNode }) => {
 
   const { data: currentUserData, status: currentUserStatus } = useCurrentUser();
 
-  const chatNodeId = edges.length === 1 && edges[0].to.node;
+  // Same as in node-chatbox: follow the outgoing edge instead of requiring
+  // this node to have exactly one.
+  const chatNodeId = edges.find((e) => e.from.node === node.id)?.to.node;
 
   // we want to open also the chat node
   const handleOpen = () => {

--- a/packages/modules/chats/src/lib/components/node-chat/node-chatbox.tsx
+++ b/packages/modules/chats/src/lib/components/node-chat/node-chatbox.tsx
@@ -103,7 +103,11 @@ export const NodeChatbox = ({ node }: { node: TGraphNode }) => {
     usersInfo.set(uid, u);
   });
 
-  const anchorNodeId = edges.length === 1 && edges[0].from.node;
+  // The anchor is whatever points at this node. Keyed off the incoming edge
+  // rather than "there is exactly one edge", so a second edge on the chat node
+  // does not silently turn the buttons below into no-ops.
+  const anchorNodeId = edges.find((e) => e.to.node === useNodeValue.id)?.from
+    .node;
 
   // we want to close the anchor node rather than this node
   const handleClose = () => {

--- a/packages/modules/collab/src/lib/collab-hooks.spec.tsx
+++ b/packages/modules/collab/src/lib/collab-hooks.spec.tsx
@@ -163,6 +163,46 @@ describe('Collab Hooks with CollabProjectProvider', () => {
       );
     });
 
+    it('should subscribe once across re-renders, despite a new key array each render', () => {
+      const { Wrapper, mocks } = createWrapper();
+
+      // Every call site passes an array literal, so the hook receives a new
+      // reference on every render. Re-subscribing on each of them dropped the
+      // last observer of the key, which made the overrider re-attach and
+      // replay — an infinite render loop.
+      const { rerender } = renderHook(
+        () => useLocalSharedData(['tabs:tabs'], (d) => d['tabs:tabs']),
+        { wrapper: Wrapper }
+      );
+
+      rerender();
+      rerender();
+
+      expect(mocks.localOverrider.observe).toHaveBeenCalledTimes(1);
+      expect(mocks.localOverrider.unobserve).not.toHaveBeenCalled();
+    });
+
+    it('should re-subscribe when the observed keys change', () => {
+      const { Wrapper, mocks } = createWrapper();
+
+      const { rerender } = renderHook(
+        ({ keys }: { keys: string[] }) =>
+          useLocalSharedData(keys, (d) => d[keys[0]]),
+        { wrapper: Wrapper, initialProps: { keys: ['tabs:tabs'] } }
+      );
+
+      rerender({ keys: ['whiteboard:views'] });
+
+      expect(mocks.localOverrider.unobserve).toHaveBeenCalledWith(
+        ['tabs:tabs'],
+        expect.any(Function)
+      );
+      expect(mocks.localOverrider.observe).toHaveBeenCalledWith(
+        ['whiteboard:views'],
+        expect.any(Function)
+      );
+    });
+
     it('should throw error when used without CollabProjectProvider', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 

--- a/packages/modules/collab/src/lib/collab-hooks.ts
+++ b/packages/modules/collab/src/lib/collab-hooks.ts
@@ -67,17 +67,28 @@ export const useLocalSharedData = <TSharedData extends TValidSharedData>(
   const [, refresh] = useState({});
   const updateComponent = useRef(() => refresh({}));
 
-  // Subscribe to changes
+  // Every call site passes an array literal, so `observe` is a new reference
+  // on every render. Depending on it directly re-subscribed once per render,
+  // and since `unobserve` detaches the overrider from the shared map as soon
+  // as a key has no observer left, each render tore the shared-data
+  // subscription down and built it back up. Key it on the contents instead.
+  const keysId = (observe as string[]).join('\u0000');
+  const keys = useMemo(() => keysId.split('\u0000'), [keysId]);
+
+  // Subscribe to changes. This has to happen during render: the first
+  // `observe` of a key is what materializes it in the overrider's local
+  // copy, and `f` reads that copy below on this very render.
   useMemo(() => {
-    localOverrider.observe(observe as string[], updateComponent.current);
-  }, [localOverrider, observe]);
+    localOverrider.observe(keys, updateComponent.current);
+  }, [localOverrider, keys]);
 
   // Cleanup subscription
   useEffect(() => {
+    const update = updateComponent.current;
     return () => {
-      localOverrider.unobserve(observe as string[], updateComponent.current);
+      localOverrider.unobserve(keys, update);
     };
-  }, [localOverrider, observe]);
+  }, [localOverrider, keys]);
 
   return f(localOverrider.getData());
 };

--- a/packages/modules/collab/src/lib/overrider.spec.ts
+++ b/packages/modules/collab/src/lib/overrider.spec.ts
@@ -1,0 +1,94 @@
+import { LocalOverrider } from './overrider';
+
+//
+
+/** Minimal stand-in for a collab SharedMap: copy + observe/unobserve. */
+const makeSharedMap = (entries: [string, unknown][] = []) => {
+  const data = new Map(entries);
+  const observers: (() => void)[] = [];
+  return {
+    data,
+    copy: () => new Map(data),
+    observe: (o: () => void) => observers.push(o),
+    unobserve: (o: () => void) => {
+      const i = observers.indexOf(o);
+      if (i !== -1) observers.splice(i, 1);
+    },
+    observerCount: () => observers.length,
+    set(key: string, value: unknown) {
+      data.set(key, value);
+      observers.slice().forEach((o) => o());
+    },
+  };
+};
+
+const makeOverrider = () => {
+  const map = makeSharedMap([['a', { n: 1 }]]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const overrider = new LocalOverrider({ 'test:map': map } as any);
+  return { map, overrider };
+};
+
+//
+
+describe('LocalOverrider', () => {
+  it('materializes a key on the first observe without calling observers', () => {
+    const { map, overrider } = makeOverrider();
+    const observer = jest.fn();
+
+    overrider.observe(['test:map'], observer);
+
+    // The subscriber reads the data itself right after subscribing, so
+    // notifying here would re-enter the caller — for React, mid-render.
+    expect(observer).not.toHaveBeenCalled();
+    expect(overrider.getData()['test:map']).toEqual(map.data);
+  });
+
+  it('notifies observers when the shared data changes', () => {
+    const { map, overrider } = makeOverrider();
+    const observer = jest.fn();
+
+    overrider.observe(['test:map'], observer);
+    map.set('b', { n: 2 });
+
+    expect(observer).toHaveBeenCalledTimes(1);
+    expect(overrider.getData()['test:map']).toEqual(
+      new Map([
+        ['a', { n: 1 }],
+        ['b', { n: 2 }],
+      ])
+    );
+  });
+
+  it('detaches from the shared data once the last observer leaves', () => {
+    const { map, overrider } = makeOverrider();
+    const observer = jest.fn();
+
+    overrider.observe(['test:map'], observer);
+    expect(map.observerCount()).toBe(1);
+
+    overrider.unobserve(['test:map'], observer);
+    expect(map.observerCount()).toBe(0);
+
+    // and re-attaches cleanly, still without notifying
+    overrider.observe(['test:map'], observer);
+    expect(map.observerCount()).toBe(1);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it('keeps observing while another observer remains', () => {
+    const { map, overrider } = makeOverrider();
+    const first = jest.fn();
+    const second = jest.fn();
+
+    overrider.observe(['test:map'], first);
+    overrider.observe(['test:map'], second);
+    overrider.unobserve(['test:map'], first);
+
+    expect(map.observerCount()).toBe(1);
+
+    map.set('b', { n: 2 });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/modules/collab/src/lib/overrider.ts
+++ b/packages/modules/collab/src/lib/overrider.ts
@@ -87,7 +87,11 @@ export class LocalOverrider<
         const sdObserver = () => this.update(key as string);
         this.sdObservers.set(key as string, sdObserver);
         this.sharedData[key].observe(sdObserver);
-        sdObserver();
+        // Materialize the key, but do not call the observers: whoever is
+        // subscribing reads the data right after this call, and nothing has
+        // changed for the others. Notifying here called back into React from
+        // inside the render of the component that was subscribing.
+        this.refresh(key as string);
       }
     });
   }
@@ -108,11 +112,16 @@ export class LocalOverrider<
 
   //
 
-  private update(key: string) {
+  /** Refresh the local copy of a key and re-apply its override functions. */
+  private refresh(key: string) {
     this.localSharedData[key] = this.sharedData[key].copy();
     this.ofs.get(key)?.forEach((of) => {
       of.apply(this.localSharedData as TValidSharedDataToCopy<TSharedData>);
     });
+  }
+
+  private update(key: string) {
+    this.refresh(key);
     this.callKeyObservers(key);
   }
 

--- a/packages/modules/core-graph/src/lib/core-hooks.spec.ts
+++ b/packages/modules/core-graph/src/lib/core-hooks.spec.ts
@@ -1,0 +1,79 @@
+import { TEdge } from './core-types';
+
+// Answer with a local copy shaped exactly like LocalOverrider.getData():
+// keyed by the full shared-data key, not by a bare 'edges'. The state lives on
+// `global` because a jest.mock factory may not close over module scope.
+jest.mock('@holistix-forge/collab/frontend', () => ({
+  useLocalSharedData: (
+    observe: string[],
+    f: (data: Record<string, unknown>) => unknown
+  ) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = global as any;
+    g.__observedKeys.push(observe);
+    return f(g.__localSharedData);
+  },
+}));
+
+const { useNodeEdges } = require('./core-hooks');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g = global as any;
+
+const edge = (from: string, to: string): TEdge =>
+  ({
+    from: { node: from, connectorName: 'outputs' },
+    to: { node: to, connectorName: 'inputs' },
+  } as TEdge);
+
+describe('useNodeEdges', () => {
+  beforeEach(() => {
+    g.__localSharedData = {};
+    g.__observedKeys = [];
+  });
+
+  it('should observe the core-graph:edges key', () => {
+    g.__localSharedData = { 'core-graph:edges': [] };
+
+    useNodeEdges('a');
+
+    expect(g.__observedKeys).toEqual([['core-graph:edges']]);
+  });
+
+  it('should read the edges from the namespaced key, not from sd.edges', () => {
+    // Regression: the hook used to select the whole shared data and
+    // destructure `edges` off it, a key the local copy never has. It returned
+    // an empty array to every caller.
+    g.__localSharedData = { 'core-graph:edges': [edge('anchor', 'chat')] };
+
+    expect(useNodeEdges('chat')).toHaveLength(1);
+  });
+
+  it('should return the edges entering the node', () => {
+    g.__localSharedData = {
+      'core-graph:edges': [edge('anchor', 'chat'), edge('other', 'elsewhere')],
+    };
+
+    expect(useNodeEdges('chat')).toEqual([edge('anchor', 'chat')]);
+  });
+
+  it('should return the edges leaving the node', () => {
+    g.__localSharedData = {
+      'core-graph:edges': [edge('anchor', 'chat'), edge('other', 'elsewhere')],
+    };
+
+    expect(useNodeEdges('anchor')).toEqual([edge('anchor', 'chat')]);
+  });
+
+  it('should return an empty array for a node with no edge', () => {
+    g.__localSharedData = { 'core-graph:edges': [edge('anchor', 'chat')] };
+
+    expect(useNodeEdges('lonely')).toEqual([]);
+  });
+
+  it('should return an empty array when the key is not materialized yet', () => {
+    g.__localSharedData = {};
+
+    expect(useNodeEdges('chat')).toEqual([]);
+  });
+});

--- a/packages/modules/core-graph/src/lib/core-hooks.ts
+++ b/packages/modules/core-graph/src/lib/core-hooks.ts
@@ -6,10 +6,14 @@ const getNodeEdges = (edges: Array<TEdge>, nid: string) =>
   edges.filter((edge) => edge.from.node === nid || edge.to.node === nid);
 
 export const useNodeEdges = (id: string) => {
-  const { edges } = useLocalSharedData<TCoreSharedData>(
+  // The local copy is keyed by the full shared-data key, so the edges live
+  // under 'core-graph:edges'. Selecting `sd` and destructuring `edges` off it
+  // read a key that has never existed: this hook returned an empty array to
+  // every caller, which silently disabled anything that looks up a node's
+  // neighbours — the chat node's reduce and filter-out buttons among them.
+  const edges = useLocalSharedData<TCoreSharedData>(
     ['core-graph:edges'],
-    (sd) => sd
+    (sd) => sd['core-graph:edges']
   );
-  const nodeEdges = getNodeEdges(edges || [], id);
-  return nodeEdges;
+  return getNodeEdges(edges || [], id);
 };

--- a/packages/modules/whiteboard/src/lib/components/reactflow-layer.tsx
+++ b/packages/modules/whiteboard/src/lib/components/reactflow-layer.tsx
@@ -209,6 +209,9 @@ export const ReactflowLayer = ({
 
   const lsdm = useLocalSharedDataManager<TWhiteboardSharedData>();
 
+  // Read before the drag handlers below: they depend on `mode`.
+  const { resetEdgeMenu, mode } = useSpaceContext();
+
   const { handleNodeDrag, handleNodeDragStop } = useMemo(() => {
     //
 
@@ -275,8 +278,16 @@ export const ReactflowLayer = ({
     ) => {
       const nodeView = spaceState.getNodes().find((n) => n.id === node.id);
       if (!nodeView) return;
-      if (nodeView.disabledFeatures?.includes('frontend-move-node')) {
-        console.log('node is disabled for moving');
+      // `frontend-move-node` exists so a node that needs the pointer for its
+      // own content — an Excalidraw drawing captures it to draw — is not
+      // dragged out from under the user. Move node mode is the deliberate
+      // escape hatch from exactly that, so the flag must not apply there:
+      // otherwise the mode silently does nothing on those nodes while working
+      // everywhere else, which is precisely how this was reported.
+      if (
+        mode !== 'move-node' &&
+        nodeView.disabledFeatures?.includes('frontend-move-node')
+      ) {
         return;
       }
       es.dispatch({
@@ -305,7 +316,7 @@ export const ReactflowLayer = ({
       handleNodeDrag,
       handleNodeDragStop,
     };
-  }, [dispatcher, lsdm, spaceState, viewId]);
+  }, [dispatcher, lsdm, spaceState, viewId, mode]);
 
   //
   //
@@ -395,8 +406,6 @@ export const ReactflowLayer = ({
   }, [selections, viewId]);
 
   //
-
-  const { resetEdgeMenu } = useSpaceContext();
 
   const handlePaneClick = useCallback(
     // Handle left click on pane here

--- a/packages/ui-toolkit/src/lib/useRegisterListener.spec.tsx
+++ b/packages/ui-toolkit/src/lib/useRegisterListener.spec.tsx
@@ -1,0 +1,79 @@
+import { act, render } from '@testing-library/react';
+import { Listenable } from '@holistix-forge/simple-types';
+
+import { useRegisterListener } from './useRegisterListener';
+
+//
+
+class TestStore extends Listenable {
+  notify() {
+    this.notifyListeners();
+  }
+
+  listenerCount() {
+    // `listeners` is private on Listenable, but the count is exactly what
+    // this hook's contract is about: one subscription per mounted component.
+    return (this as unknown as { listeners: unknown[] }).listeners.length;
+  }
+}
+
+//
+
+describe('useRegisterListener', () => {
+  it('registers a single listener and keeps it across re-renders', () => {
+    const store = new TestStore();
+    let renders = 0;
+
+    const Component = () => {
+      useRegisterListener(store, 'test-label');
+      renders++;
+      return <div>renders: {renders}</div>;
+    };
+
+    render(<Component />);
+    expect(store.listenerCount()).toBe(1);
+
+    act(() => store.notify());
+    expect(renders).toBe(2);
+    expect(store.listenerCount()).toBe(1);
+
+    act(() => store.notify());
+    expect(renders).toBe(3);
+    // The regression this guards: the listener list used to grow by one on
+    // every render, so each notification fanned out into more work than the
+    // last one.
+    expect(store.listenerCount()).toBe(1);
+  });
+
+  it('removes its listener on unmount', () => {
+    const store = new TestStore();
+
+    const Component = () => {
+      useRegisterListener(store);
+      return null;
+    };
+
+    const { unmount } = render(<Component />);
+    expect(store.listenerCount()).toBe(1);
+
+    unmount();
+    expect(store.listenerCount()).toBe(0);
+  });
+
+  it('re-subscribes when the observed object changes', () => {
+    const first = new TestStore();
+    const second = new TestStore();
+
+    const Component = ({ store }: { store: TestStore }) => {
+      useRegisterListener(store);
+      return null;
+    };
+
+    const { rerender } = render(<Component store={first} />);
+    expect(first.listenerCount()).toBe(1);
+
+    rerender(<Component store={second} />);
+    expect(first.listenerCount()).toBe(0);
+    expect(second.listenerCount()).toBe(1);
+  });
+});

--- a/packages/ui-toolkit/src/lib/useRegisterListener.ts
+++ b/packages/ui-toolkit/src/lib/useRegisterListener.ts
@@ -3,15 +3,31 @@ import { Listenable } from '@holistix-forge/simple-types';
 
 //
 
+/**
+ * Re-render the calling component whenever `o` notifies its listeners.
+ *
+ * Subscribe with the very function we unsubscribe with: `Listenable`
+ * removes listeners by identity, so registering an anonymous wrapper and
+ * unregistering `forceUpdate` never matched and every listener stayed in
+ * the list forever. With no dependency array on top of that, the effect
+ * re-ran on every render, so the component accumulated one dead listener
+ * per render and every notification then did work proportional to how long
+ * the component had been alive.
+ *
+ * The extra `args` are debug labels only — `addListener` ignores them —
+ * so they are deliberately not part of the dependency list.
+ */
+
 export const useRegisterListener = (o: Listenable, ...args: any) => {
   const [, _forceUpdate] = useState({});
   const forceUpdate = useCallback(() => {
-    // console.log('XXXXXXXXXXXXXXXXXXXXX useRegisterListener Update', ...args);
     _forceUpdate({});
   }, []);
   useEffect(() => {
-    o.addListener(() => forceUpdate(), ...args);
+    o.addListener(forceUpdate, ...args);
     return () => o.removeListener?.(forceUpdate, ...args);
-  });
+    // `args` is a rest parameter, so it is a new array on every render and
+    // must stay out of this list — see the note above.
+  }, [o, forceUpdate]);
   return forceUpdate;
 };

--- a/scripts/local-dev/create-env.sh
+++ b/scripts/local-dev/create-env.sh
@@ -286,10 +286,18 @@ NODE_TLS_REJECT_UNAUTHORIZED=0
 # reload, so a single debugging session exhausts the OAuth budget and then locks
 # you out for the rest of the window with an opaque 429 — which looks exactly
 # like "the app is broken and shows no data".
+#
+# The global and API budgets need the same treatment. A debugging session with
+# repeated reloads goes through the 500-request global budget well inside the
+# 15-minute window, and once it is gone every call — including the OAuth
+# preflight — comes back 429, which surfaces in the browser as an opaque
+# "Failed to fetch" and a project stuck on "Loading project...".
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_AUTH_MAX=100
 RATE_LIMIT_OAUTH_MAX=500
 RATE_LIMIT_SENSITIVE_MAX=300
+RATE_LIMIT_API_MAX=5000
+RATE_LIMIT_GLOBAL_MAX=20000
 EOF
 
 # 8. Create Nginx server blocks (Stage 1 - Main nginx with SSL termination)

--- a/scripts/local-dev/setup-observability.sh
+++ b/scripts/local-dev/setup-observability.sh
@@ -115,6 +115,16 @@ receivers:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
+        # The browser posts traces to this receiver from https://<domain>,
+        # a different origin, so it preflights. Without these headers every
+        # trace is rejected and the console fills with CORS errors — ~29 per
+        # page load, which buries any real error underneath.
+        cors:
+          allowed_origins:
+            - "https://*"
+            - "http://localhost:*"
+          allowed_headers:
+            - "*"
 
 processors:
   batch:


### PR DESCRIPTION
The chat node was unusable because the project page re-rendered in a loop: `useRegisterListener` accumulated one dead listener per render (it unsubscribed a function it had never subscribed), `useLocalSharedData` re-subscribed on every render because every call site passes an array literal, `LocalOverrider.observe` called back into React mid-render, and `ModuleDataProvider` keyed its memo on those same unstable references — so each render reloaded every frontend module, handed the whiteboard a new node component type and remounted every node; this fixes each layer and adds a `staleTime` to `useCurrentUser` to stop the `/me` flood that kept the loop fed.

Separately, the gateway never loaded the notion, airtable, excalidraw, socials and chats backends, so those menu entries dispatched their own module events with nothing to handle them and silently created no node.

Also included: move-node mode now overrides a node's `frontend-move-node` disable flag (the mode did nothing on Excalidraw nodes, which set it so drawing keeps the pointer), the OTLP HTTP receiver accepts browser origins so traces are no longer rejected by CORS (~29 console errors per page load), and local-dev environments get larger API and global rate-limit budgets so a debugging session stops 429-ing itself into an opaque "Failed to fetch".

New unit tests cover `LocalOverrider`, `useRegisterListener`, and the collab hook's subscription behaviour across re-renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
